### PR TITLE
Add ExportOptions (clipping, simplification) to GPX, Shapefile, GeoPackage write methods

### DIFF
--- a/Sources/MVTCLI/MergeOptions.swift
+++ b/Sources/MVTCLI/MergeOptions.swift
@@ -273,8 +273,10 @@ extension CLI.MergeOptions {
         }
         else {
             switch resolvedOutputFormat {
-            case .geoJson: exportOptions.bufferSize = .extent(0)
-            default:       exportOptions.bufferSize = .extent(512)
+            case .geoJson, .gpx, .shapefile, .geopackage:
+                exportOptions.bufferSize = .extent(0)
+            default:
+                exportOptions.bufferSize = .extent(512)
             }
         }
 
@@ -311,10 +313,13 @@ extension CLI.MergeOptions {
         }
 
         if let outputUrl {
-            try await Self.writeTile(tile, format: resolvedOutputFormat, to: outputUrl,
-                                     options: exportOptions,
-                                     prettyPrint: mergeOptions.prettyPrint,
-                                     propertyName: mergeOptions.disableOutputLayerProperty ? nil : mergeOptions.propertyName)
+            try await Self.writeTile(
+                tile,
+                format: resolvedOutputFormat,
+                to: outputUrl,
+                options: exportOptions,
+                prettyPrint: mergeOptions.prettyPrint,
+                propertyName: mergeOptions.disableOutputLayerProperty ? nil : mergeOptions.propertyName)
         }
         else if let resultGeoJson = tile.toGeoJson(
             prettyPrinted: mergeOptions.prettyPrint,
@@ -355,15 +360,15 @@ extension CLI.MergeOptions {
             tile.writeMLT(to: url, options: options)
 
         case .gpx:
-            guard tile.writeGPX(to: url) else {
+            guard tile.writeGPX(to: url, options: options) else {
                 throw CLIError("Failed to write GPX")
             }
 
         case .shapefile:
-            try tile.writeShapefile(to: url)
+            try tile.writeShapefile(to: url, options: options)
 
         case .geopackage:
-            try await tile.writeGeoPackage(to: url)
+            try await tile.writeGeoPackage(to: url, options: options)
         }
     }
     

--- a/Sources/MVTTools/Coders/ExportOptions.swift
+++ b/Sources/MVTTools/Coders/ExportOptions.swift
@@ -77,4 +77,74 @@ extension VectorTile {
 
     }
 
+    /// Process features according to the given export options (clipping,
+    /// simplification, or both).
+    ///
+    /// When `options` is `nil` or no processing is needed, the original
+    /// features are returned unchanged.
+    ///
+    /// - Parameters:
+    ///   - features: The features to process.
+    ///   - options: Export options controlling clipping and simplification.
+    /// - Returns: The processed features, or the original array if no
+    ///   processing was requested.
+    func processFeatures(
+        _ features: [Feature],
+        options: VectorTile.ExportOptions? = nil
+    ) -> [Feature] {
+        guard let options else { return features }
+
+        var bufferSize = 0
+        switch options.bufferSize {
+        case .no:
+            bufferSize = 0
+        case let .extent(extent):
+            bufferSize = extent
+        case let .pixel(pixel):
+            bufferSize = Int((Double(pixel) / Double(VectorTile.ExportOptions.tileSize)) * Double(VectorTile.ExportOptions.extent))
+        }
+
+        var simplifyDistance: CLLocationDistance = 0.0
+        switch options.simplifyFeatures {
+        case .no:
+            simplifyDistance = 0.0
+        case let .extent(extent):
+            let tileBoundsInMeters = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg3857)
+            simplifyDistance = (tileBoundsInMeters.southEast.longitude - tileBoundsInMeters.southWest.longitude)
+                / Double(VectorTile.ExportOptions.extent) * Double(extent)
+        case let .meters(meters):
+            simplifyDistance = meters
+        }
+
+        var clipBoundingBox: BoundingBox?
+        if bufferSize != 0 {
+            clipBoundingBox = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg4326)
+            if let box = clipBoundingBox {
+                let sqrt2 = 2.0.squareRoot()
+                let diagonal = Double(VectorTile.ExportOptions.extent) * sqrt2
+                let bufferDiagonal = Double(bufferSize) * sqrt2
+                let factor = bufferDiagonal / diagonal
+                let diagonalLength = box.southWest.distance(from: box.northEast)
+                clipBoundingBox = box.expanded(byDistance: diagonalLength * factor)
+            }
+        }
+
+        guard clipBoundingBox != nil || simplifyDistance > 0.0 else { return features }
+
+        return features.compactMap { feature in
+            let clipped: Feature
+            if let clipBoundingBox {
+                guard let c = feature.clipped(to: clipBoundingBox) else { return nil }
+                clipped = c
+            }
+            else {
+                clipped = feature
+            }
+            if simplifyDistance > 0.0 {
+                return clipped.simplified(tolerance: simplifyDistance)
+            }
+            return clipped
+        }
+    }
+
 }

--- a/Sources/MVTTools/Coders/GPX/VectorTile+GPX.swift
+++ b/Sources/MVTTools/Coders/GPX/VectorTile+GPX.swift
@@ -110,9 +110,13 @@ extension VectorTile {
     /// Export the tile's content as GPX data.
     ///
     /// - Parameter creator: The value for the `creator` attribute in the GPX output (default `"MVTTools"`).
+    /// - Parameter options: Export options controlling simplification.
     /// - Returns: The GPX data, or `nil` if serialization fails.
-    public func toGpxData(creator: String = "MVTTools") -> Data? {
-        let allFeatures = layers.values.flatMap(\.features)
+    public func toGpxData(
+        creator: String = "MVTTools",
+        options: VectorTile.ExportOptions? = nil
+    ) -> Data? {
+        let allFeatures = processFeatures(layers.values.flatMap(\.features), options: options)
         let fc = FeatureCollection(allFeatures)
         return try? fc.gpxData(creator: creator)
     }
@@ -121,10 +125,15 @@ extension VectorTile {
     ///
     /// - Parameter url: The destination file URL.
     /// - Parameter creator: The value for the `creator` attribute in the GPX output.
+    /// - Parameter options: Export options controlling simplification.
     /// - Returns: `true` if the write succeeds, `false` otherwise.
     @discardableResult
-    public func writeGPX(to url: URL, creator: String = "MVTTools") -> Bool {
-        guard let data: Data = toGpxData(creator: creator) else { return false }
+    public func writeGPX(
+        to url: URL,
+        creator: String = "MVTTools",
+        options: VectorTile.ExportOptions? = nil
+    ) -> Bool {
+        guard let data: Data = toGpxData(creator: creator, options: options) else { return false }
         do {
             try data.write(to: url)
             return true

--- a/Sources/MVTTools/Coders/GeoJSON/VectorTile+GeoJSON.swift
+++ b/Sources/MVTTools/Coders/GeoJSON/VectorTile+GeoJSON.swift
@@ -123,66 +123,12 @@ extension VectorTile {
         layerProperty: String? = nil,
         options: VectorTile.ExportOptions? = nil
     ) -> Data? {
-        var simplifyDistance: CLLocationDistance = 0.0
-        var clipBoundingBox: BoundingBox?
-
-        if let options {
-            var bufferSize = 0
-            switch options.bufferSize {
-            case .no:
-                bufferSize = 0
-            case let .extent(extent):
-                bufferSize = extent
-            case let .pixel(pixel):
-                bufferSize = Int((Double(pixel) / Double(VectorTile.ExportOptions.tileSize)) * Double(VectorTile.ExportOptions.extent))
-            }
-
-            switch options.simplifyFeatures {
-            case .no:
-                simplifyDistance = 0.0
-            case let .extent(extent):
-                let tileBoundsInMeters = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg3857)
-                simplifyDistance = (tileBoundsInMeters.southEast.longitude - tileBoundsInMeters.southWest.longitude) / Double(VectorTile.ExportOptions.extent) * Double(extent)
-            case let .meters(meters):
-                simplifyDistance = meters
-            }
-
-            if bufferSize != 0 {
-                clipBoundingBox = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg4326)
-
-                if let boundingBoxToExpand = clipBoundingBox {
-                    let sqrt2 = 2.0.squareRoot()
-                    let diagonal = Double(VectorTile.ExportOptions.extent) * sqrt2
-                    let bufferDiagonal = Double(bufferSize) * sqrt2
-                    let factor = bufferDiagonal / diagonal
-
-                    let diagonalLength = boundingBoxToExpand.southWest.distance(from: boundingBoxToExpand.northEast)
-                    let distance = diagonalLength * factor
-
-                    clipBoundingBox = boundingBoxToExpand.expanded(byDistance: distance)
-                }
-            }
-        }
-
         var allFeatures: [Feature] = []
 
         for (layerName, layerContainer) in layers {
             if layerNames.isNotEmpty, !layerNames.contains(layerName) { continue }
 
-            let layerFeatures: [Feature] = if let clipBoundingBox {
-                if simplifyDistance > 0.0 {
-                    layerContainer.features.compactMap({ $0.clipped(to: clipBoundingBox)?.simplified(tolerance: simplifyDistance) })
-                }
-                else {
-                    layerContainer.features.compactMap({ $0.clipped(to: clipBoundingBox) })
-                }
-            }
-            else if simplifyDistance > 0.0 {
-                layerContainer.features.compactMap({ $0.simplified(tolerance: simplifyDistance) })
-            }
-            else {
-                layerContainer.features
-            }
+            let layerFeatures = processFeatures(layerContainer.features, options: options)
 
             for feature in layerFeatures {
                 var feature = feature

--- a/Sources/MVTTools/Coders/GeoPackage/VectorTile+GeoPackage.swift
+++ b/Sources/MVTTools/Coders/GeoPackage/VectorTile+GeoPackage.swift
@@ -92,11 +92,13 @@ extension VectorTile {
     ///     with a `"gpkg_layer"` property to preserve layer information.
     ///     When `nil`, one table per layer is created.
     ///   - createSpatialIndex: Whether to create a spatial (rtree) index.
+    ///   - options: Export options controlling simplification.
     /// - Throws: ``GeoPackageError`` or file I/O errors.
     public func writeGeoPackage(
         to url: URL,
         table: String? = nil,
-        createSpatialIndex: Bool = false
+        createSpatialIndex: Bool = false,
+        options: VectorTile.ExportOptions? = nil
     ) async throws {
         let conn = try GeoPackageConnection(url: url, skipValidation: true)
         try await conn.createMetadata()
@@ -104,7 +106,7 @@ extension VectorTile {
         if let table {
             var allFeatures: [Feature] = []
             for layerName in layerNames {
-                let features = self.features(for: layerName)
+                let features = processFeatures(self.features(for: layerName), options: options)
                 allFeatures.append(contentsOf: features.map { feature in
                     var f = feature
                     f.properties["gpkg_layer"] = layerName
@@ -117,7 +119,7 @@ extension VectorTile {
         }
         else {
             for layerName in layerNames {
-                let features = self.features(for: layerName)
+                let features = processFeatures(self.features(for: layerName), options: options)
                 guard features.isNotEmpty else { continue }
                 let tagged = features.map { feature -> Feature in
                     var f = feature

--- a/Sources/MVTTools/Coders/Shapefile/VectorTile+Shapefile.swift
+++ b/Sources/MVTTools/Coders/Shapefile/VectorTile+Shapefile.swift
@@ -73,11 +73,13 @@ extension VectorTile {
     ///   - url: The output base URL (extension `.shp`, `.dbf`, `.prj` are added).
     ///   - layerName: When non-nil, only this layer is exported. When `nil`, all layers are merged.
     ///   - encoding: The string encoding for the DBF file (default `.utf8`).
+    ///   - options: Export options controlling simplification.
     /// - Throws: ``ShapefileError/mixedGeometry`` if the exported features have mixed geometry types.
     public func writeShapefile(
         to url: URL,
         layerName: String? = nil,
-        encoding: String.Encoding = .utf8
+        encoding: String.Encoding = .utf8,
+        options: VectorTile.ExportOptions? = nil
     ) throws {
         let features: [Feature]
         if let layerName {
@@ -89,12 +91,13 @@ extension VectorTile {
 
         guard features.isNotEmpty else { return }
 
-        let geometryTypes = Set(features.map(\.geometry.type))
+        let processed = processFeatures(features, options: options)
+        let geometryTypes = Set(processed.map(\.geometry.type))
         guard geometryTypes.count == 1 else {
             throw ShapefileError.mixedGeometry(types: geometryTypes)
         }
 
-        let fc = FeatureCollection(features)
+        let fc = FeatureCollection(processed)
         try ShapefileCoder.write(fc, to: url, encoding: encoding)
     }
 
@@ -103,10 +106,12 @@ extension VectorTile {
     /// - Parameters:
     ///   - directory: The output directory. One `.shp`/`.dbf`/`.prj` set per layer.
     ///   - encoding: The string encoding for DBF files (default `.utf8`).
+    ///   - options: Export options controlling simplification.
     /// - Throws: ``ShapefileError`` or file I/O errors.
     public func writeShapefiles(
         to directory: URL,
-        encoding: String.Encoding = .utf8
+        encoding: String.Encoding = .utf8,
+        options: VectorTile.ExportOptions? = nil
     ) throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
@@ -114,7 +119,8 @@ extension VectorTile {
             let features = self.features(for: layerName)
             guard features.isNotEmpty else { continue }
 
-            let fc = FeatureCollection(features)
+            let processed = processFeatures(features, options: options)
+            let fc = FeatureCollection(processed)
             let fileUrl = directory.appendingPathComponent(layerName)
             try ShapefileCoder.write(fc, to: fileUrl, encoding: encoding)
         }


### PR DESCRIPTION
- Added processFeatures(_:options:) helper on VectorTile in ExportOptions.swift, handling both clipping (buffer) and simplification, shared across all formats
- GeoJSON toGeoJson() now uses the shared helper instead of inline logic
- GPX: toGpxData() and writeGPX() accept optional ExportOptions
- Shapefile: writeShapefile() and writeShapefiles() accept optional ExportOptions
- GeoPackage: writeGeoPackage() accepts optional ExportOptions
- MergeOptions writeTile forwards options to all format cases
- Buffer default changed to .extent(0) for GPX/Shapefile/GeoPackage (non-tile formats)