### PR TITLE
Add 'mvt rezoom' subcommand for overzooming and underzooming tiles

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f61ea9b59d7db89fc280a603c0c5d20d42197e5dbca9cc2efe8533c0ecb66603",
+  "originHash" : "0b9d13ee128afaaf9faa04786776ef22f024f2d5292301ffabbb4f4c6631698a",
   "pins" : [
     {
       "identity" : "gis-tools",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Outdooractive/gis-tools",
       "state" : {
-        "revision" : "93e41e54a3703ebeeac5dff3f909c36d0fbd853c",
-        "version" : "2.0.6"
+        "revision" : "5a8121e6d51d6ed990b5f66f6c96a538215821e5",
+        "version" : "2.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["MVTTools"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Outdooractive/gis-tools", from: "2.0.6"),
+        .package(url: "https://github.com/Outdooractive/gis-tools", from: "2.0.7"),
         .package(url: "https://github.com/Outdooractive/gis-tools-geopackage", from: "1.0.1"),
         .package(url: "https://github.com/Outdooractive/gis-tools-gpx", from: "1.0.4"),
         .package(url: "https://github.com/Outdooractive/gis-tools-shapefile", from: "1.0.2"),

--- a/Sources/MVTCLI/CLI.swift
+++ b/Sources/MVTCLI/CLI.swift
@@ -34,6 +34,7 @@ struct CLI: AsyncParsableCommand {
             Import.self,
             Export.self,
             Load.self,
+            Rezoom.self,
         ],
         defaultSubcommand: Dump.self)
 

--- a/Sources/MVTCLI/MergeOptions.swift
+++ b/Sources/MVTCLI/MergeOptions.swift
@@ -313,7 +313,7 @@ extension CLI.MergeOptions {
         }
 
         if let outputUrl {
-            try await Self.writeTile(
+            try await CLI.writeTile(
                 tile,
                 format: resolvedOutputFormat,
                 to: outputUrl,
@@ -335,41 +335,5 @@ extension CLI.MergeOptions {
         }
     }
 
-    /// Write a tile to a file in the given format.
-    private static func writeTile(
-        _ tile: VectorTile,
-        format: TileFormat,
-        to url: URL,
-        options: VectorTile.ExportOptions,
-        prettyPrint: Bool,
-        propertyName: String?
-    ) async throws {
-        switch format {
-        case .geoJson:
-            guard let data = tile.toGeoJson(
-                prettyPrinted: prettyPrint,
-                layerProperty: propertyName,
-                options: options)
-            else { throw CLIError("Failed to extract the tile data as GeoJSON") }
-            try data.write(to: url, options: .atomic)
-
-        case .mvt:
-            tile.writeMVT(to: url, options: options)
-
-        case .mlt:
-            tile.writeMLT(to: url, options: options)
-
-        case .gpx:
-            guard tile.writeGPX(to: url, options: options) else {
-                throw CLIError("Failed to write GPX")
-            }
-
-        case .shapefile:
-            try tile.writeShapefile(to: url, options: options)
-
-        case .geopackage:
-            try await tile.writeGeoPackage(to: url, options: options)
-        }
-    }
-    
 }
+

--- a/Sources/MVTCLI/Rezoom.swift
+++ b/Sources/MVTCLI/Rezoom.swift
@@ -1,0 +1,329 @@
+import ArgumentParser
+import Foundation
+import GISTools
+import Logging
+import MVTTools
+
+extension CLI {
+
+    /// A command that rezooms (overzooms or underzooms) one or more
+    /// source tiles into a single output tile at a target zoom level.
+    ///
+    /// Each source tile must be an ancestor or descendant of the target
+    /// tile. Features are re-projected and clipped to the target tile's
+    /// bounding box at encode time.
+    struct Rezoom: AsyncParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            commandName: "rezoom",
+            abstract: "Overzoom or underzoom source tiles into a single output tile at a target zoom level",
+            discussion: """
+            Each source tile must be an ancestor or descendant of the target tile. \
+            Source tiles that are not related to the target are silently skipped \
+            (use --strict to abort instead).
+
+            Target tile coordinates can be specified with --target-x, --target-y, \
+            and --target-z, or inferred from the --output file path (e.g. \
+            '3_2_2.mvt' or '3/2/2.mvt').
+
+            Source tile coordinates are resolved from each file's path or with \
+            --x, --y, --z.
+
+            Examples:
+              mvt rezoom --output ./tiles/3_2_2.mvt source_2_1_1.mvt
+              mvt rezoom --target-z 3 --target-x 2 --target-y 2 \\
+                  --output out.mvt --strict source.mvt
+            """)
+
+        @Option(
+            name: .customLong("target-x"),
+            help: "Target tile x coordinate (or inferred from --output path).")
+        var targetX: Int?
+
+        @Option(
+            name: .customLong("target-y"),
+            help: "Target tile y coordinate (or inferred from --output path).")
+        var targetY: Int?
+
+        @Option(
+            name: .customLong("target-z"),
+            help: "Target tile zoom level (or inferred from --output path).")
+        var targetZ: Int?
+
+        @Option(
+            name: [.short, .customLong("output")],
+            help: "Output file.",
+            completion: .file(extensions: ["pbf", "mvt", "mlt", "json", "geojson", "gpx", "shp", "gpkg"]))
+        var outputFile: String?
+
+        @Option(
+            name: [.customShort("O"), .long],
+            help: "Output file format (optional, one of 'auto', 'geojson', 'mvt', 'mlt', 'gpx', 'shapefile', 'geopackage').")
+        var outputFormat: TileFormat?
+
+        @Option(
+            name: [.customLong("oC", withSingleDash: true), .long],
+            help: "Output file compression level, between 0=none to 9=best. (default: 9 for mvt/mlt, none for geojson)")
+        var compressionLevel: Int?
+
+        @Option(
+            name: [.customLong("oBe", withSingleDash: true), .long],
+            help: "Output buffer extents for tiles of size \(VectorTile.ExportOptions.extent). (default: 512 for mvt/mlt, none for geojson)")
+        var bufferExtents: Int?
+
+        @Option(
+            name: [.customLong("oBp", withSingleDash: true), .long],
+            help: "Output buffer pixels for tiles of size \(VectorTile.ExportOptions.tileSize). Overrides 'buffer-extents'.")
+        var bufferPixels: Int?
+
+        @Option(
+            name: [.customLong("oSe", withSingleDash: true), .long],
+            help: "Simplify output features using tile extents. (default: no simplification)")
+        var simplifyExtents: Int?
+
+        @Option(
+            name: [.customLong("oSm", withSingleDash: true), .long],
+            help: "Simplify output features using meters. Overrides 'simplify-extents'.")
+        var simplifyMeters: Int?
+
+        @Flag(
+            name: .shortAndLong,
+            help: "Force overwrite an existing 'output' file.")
+        var forceOverwrite = false
+
+        @Flag(
+            name: .customLong("strict"),
+            help: "Abort if any source tile is not an ancestor or descendant of the target.")
+        var strict = false
+
+        @Option(
+            name: .shortAndLong,
+            help: "Filter to the specified layers (can be repeated).")
+        var layer: [String] = []
+
+        @Option(
+            name: .shortAndLong,
+            help: "Drop the specified layer (can be repeated).")
+        var dropLayer: [String] = []
+
+        @Option(
+            name: [.customShort("P"), .long],
+            help: """
+            Feature property to use for the layer name in input and output GeoJSONs/GPX. \
+            For GPX input, defaults to "gpx_type" (splits waypoints/routes/tracks).
+            """)
+        var propertyName: String = VectorTile.defaultLayerPropertyName
+
+        @Flag(
+            name: [.customLong("Di", withSingleDash: true), .long],
+            help: "Don't parse the layer name (option 'property-name') from Feature properties in the input GeoJSONs/GPX.")
+        var disableInputLayerProperty = false
+
+        @Flag(
+            name: [.customLong("Do", withSingleDash: true), .long],
+            help: "Don't add the layer name (option 'property-name') as a Feature property in the output GeoJSONs.")
+        var disableOutputLayerProperty = false
+
+        @Flag(
+            name: .shortAndLong,
+            help: "Pretty-print the output GeoJSON.")
+        var prettyPrint = false
+
+        @OptionGroup
+        var xyzOptions: XYZOptions
+
+        @OptionGroup
+        var options: Options
+
+        @Argument(
+            help: "Source tiles to rezoom (file or URL).",
+            completion: .file(extensions: ["pbf", "mvt", "mlt", "geojson", "json", "gpx", "shp", "gpkg"]))
+        var sources: [String] = []
+
+        mutating func run() async throws {
+            // 1. Resolve target coordinates
+            var targetXYZOptions = XYZOptions()
+            targetXYZOptions.x = targetX
+            targetXYZOptions.y = targetY
+            targetXYZOptions.z = targetZ
+
+            let targetXYZ: (x: Int, y: Int, z: Int)
+            if let outputFile {
+                let outputUrl = URL(fileURLWithPath: outputFile)
+                targetXYZ = try targetXYZOptions.parseXYZ(fromPaths: [outputUrl.path])
+            }
+            else {
+                guard let x = targetX, let y = targetY, let z = targetZ else {
+                    throw CLIError("Target coordinates must be specified with --target-x, --target-y, --target-z or inferred from --output path.")
+                }
+                targetXYZ = (x: x, y: y, z: z)
+            }
+
+            if options.verbose {
+                print("Target tile: \(targetXYZ.z)/\(targetXYZ.x)/\(targetXYZ.y)")
+            }
+
+            // 2. Validate output file
+            var outputUrl: URL?
+            if let outputFile {
+                outputUrl = URL(fileURLWithPath: outputFile)
+                if let outputUrl, (try? outputUrl.checkResourceIsReachable()) ?? false {
+                    if forceOverwrite {
+                        if options.verbose {
+                            print("Existing file '\(outputUrl.lastPathComponent)' will be overwritten")
+                        }
+                    }
+                    else {
+                        throw CLIError("Output file must not exist (use --force-overwrite to overwrite existing files)")
+                    }
+                }
+                // Create parent directories if needed
+                let parent = outputUrl!.deletingLastPathComponent()
+                try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            }
+
+            // 3. Load source tiles
+            let layerAllowlist = layer.asSet.subtracting(dropLayer).asArray.nonempty
+            let layerDenylist = dropLayer.asSet.subtracting(layer).asArray.nonempty
+
+            var loadedSources: [VectorTile] = []
+            for path in sources {
+                let sourceUrl = try options.parseUrl(fromPath: path)
+                let inputFormat = try TileFormat.resolve(
+                    url: sourceUrl,
+                    xyzOptions: &xyzOptions,
+                    verbose: options.verbose)
+
+                let effectiveAllowlist: [String]? = inputFormat.supportsInputLayerProperty && disableInputLayerProperty
+                    ? nil
+                    : layerAllowlist
+
+                guard var sourceTile = try await inputFormat.loadTile(
+                    from: sourceUrl,
+                    layerAllowlist: effectiveAllowlist,
+                    layerProperty: disableInputLayerProperty ? nil : propertyName,
+                    logger: options.verbose ? CLI.logger : nil)
+                else { throw CLIError("Failed to parse the tile at '\(path)'") }
+
+                if let layerDenylist {
+                    for droppedLayer in layerDenylist {
+                        sourceTile.removeLayer(droppedLayer)
+                    }
+                }
+
+                // Strict mode: check ancestry before adding
+                if strict {
+                    let sourceMap = MapTile(x: sourceTile.x, y: sourceTile.y, z: sourceTile.z)
+                    let targetMap = MapTile(x: targetXYZ.x, y: targetXYZ.y, z: targetXYZ.z)
+                    guard sourceMap.isRelated(to: targetMap) else {
+                        throw CLIError("Source tile \(sourceTile.z)/\(sourceTile.x)/\(sourceTile.y) is not an ancestor or descendant of target \(targetXYZ.z)/\(targetXYZ.x)/\(targetXYZ.y) (use --strict to abort, omit to skip).")
+                    }
+                }
+
+                if options.verbose {
+                    print("- \(sourceUrl.lastPathComponent) (\(sourceTile.z)/\(sourceTile.x)/\(sourceTile.y))")
+                }
+
+                loadedSources.append(sourceTile)
+            }
+
+            // 4. Rezoom
+            let result = VectorTile.rezoom(
+                loadedSources,
+                toTargetX: targetXYZ.x,
+                targetY: targetXYZ.y,
+                targetZ: targetXYZ.z)
+
+            if options.verbose {
+                print("Rezoomed \(loadedSources.count) source(s) into target \(targetXYZ.z)/\(targetXYZ.x)/\(targetXYZ.y) (\(result.layerNames.count) layers)")
+            }
+
+            // 5. Determine output format
+            var resolvedOutputFormat: TileFormat = outputFormat ?? .geoJson(layerProperty: nil)
+            if outputFormat == nil, let outputUrl {
+                if let extFormat = TileFormat(url: outputUrl) {
+                    resolvedOutputFormat = extFormat
+                }
+                else {
+                    switch outputUrl.pathExtension.lowercased() {
+                    case "mvt", "pbf": resolvedOutputFormat = .mvt(x: targetXYZ.x, y: targetXYZ.y, z: targetXYZ.z)
+                    case "mlt": resolvedOutputFormat = .mlt(x: targetXYZ.x, y: targetXYZ.y, z: targetXYZ.z)
+                    default: break
+                    }
+                }
+            }
+
+            // 6. Build export options
+            var exportOptions = VectorTile.ExportOptions()
+
+            if let bufferPixels, bufferPixels > 0 {
+                exportOptions.bufferSize = .pixel(bufferPixels)
+            }
+            else if let bufferExtents, bufferExtents > 0 {
+                exportOptions.bufferSize = .extent(bufferExtents)
+            }
+            else {
+                switch resolvedOutputFormat {
+                case .geoJson, .gpx, .shapefile, .geopackage:
+                    exportOptions.bufferSize = .extent(0)
+                default:
+                    exportOptions.bufferSize = .extent(512)
+                }
+            }
+
+            if outputUrl != nil {
+                if let compressionLevel {
+                    if compressionLevel > 0 {
+                        exportOptions.compression = .level(max(0, min(9, compressionLevel)))
+                    }
+                }
+                else if case .geoJson = resolvedOutputFormat {
+                    // no default compression for GeoJSON
+                }
+                else {
+                    exportOptions.compression = .level(9)
+                }
+            }
+
+            if let simplifyMeters, simplifyMeters > 0 {
+                exportOptions.simplifyFeatures = .meters(Double(simplifyMeters))
+            }
+            else if let simplifyExtents, simplifyExtents > 0 {
+                exportOptions.simplifyFeatures = .extent(simplifyExtents)
+            }
+
+            if options.verbose {
+                print("Output options:")
+                print("  - File format: \(resolvedOutputFormat)")
+                print("  - Buffer size: \(exportOptions.bufferSize)")
+                print("  - Compression: \(exportOptions.compression)")
+                print("  - Simplification: \(exportOptions.simplifyFeatures)")
+            }
+
+            // 7. Write output
+            if let outputUrl {
+                try await CLI.writeTile(
+                    result,
+                    format: resolvedOutputFormat,
+                    to: outputUrl,
+                    options: exportOptions,
+                    prettyPrint: prettyPrint,
+                    propertyName: disableOutputLayerProperty ? nil : propertyName)
+            }
+            else if let data = result.toGeoJson(
+                prettyPrinted: prettyPrint,
+                layerProperty: disableOutputLayerProperty ? nil : propertyName,
+                options: exportOptions)
+            {
+                print(String(data: data, encoding: .utf8) ?? "", terminator: "")
+                print()
+            }
+
+            if options.verbose {
+                print("Done.")
+            }
+        }
+
+    }
+
+}

--- a/Sources/MVTCLI/WriteTile.swift
+++ b/Sources/MVTCLI/WriteTile.swift
@@ -1,0 +1,57 @@
+import Foundation
+import MVTTools
+
+// MARK: - Shared tile writing helper
+
+extension CLI {
+
+    /// Writes a tile to a file in the given format.
+    ///
+    /// Shared by ``Merge``/``Import``/``Export`` (via ``MergeOptions``) and
+    /// ``Rezoom`` to avoid duplicating the format-dispatch logic.
+    ///
+    /// - Parameters:
+    ///   - tile: The tile to write.
+    ///   - format: The target file format.
+    ///   - url: The destination file URL.
+    ///   - options: Export options (buffer, compression, simplification).
+    ///   - prettyPrint: Whether to pretty-print GeoJSON output.
+    ///   - propertyName: The layer property name for GeoJSON output, or `nil`
+    ///     to omit the layer property.
+    static func writeTile(
+        _ tile: VectorTile,
+        format: TileFormat,
+        to url: URL,
+        options: VectorTile.ExportOptions,
+        prettyPrint: Bool,
+        propertyName: String?
+    ) async throws {
+        switch format {
+        case .geoJson:
+            guard let data = tile.toGeoJson(
+                prettyPrinted: prettyPrint,
+                layerProperty: propertyName,
+                options: options)
+            else { throw CLIError("Failed to extract the tile data as GeoJSON") }
+            try data.write(to: url, options: .atomic)
+
+        case .mvt:
+            tile.writeMVT(to: url, options: options)
+
+        case .mlt:
+            tile.writeMLT(to: url, options: options)
+
+        case .gpx:
+            guard tile.writeGPX(to: url, options: options) else {
+                throw CLIError("Failed to write GPX")
+            }
+
+        case .shapefile:
+            try tile.writeShapefile(to: url, options: options)
+
+        case .geopackage:
+            try await tile.writeGeoPackage(to: url, options: options)
+        }
+    }
+
+}

--- a/Sources/MVTTools/Overzoom.swift
+++ b/Sources/MVTTools/Overzoom.swift
@@ -1,0 +1,111 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+import GISTools
+import Logging
+
+// MARK: - Rezoom (overzoom / underzoom)
+
+extension VectorTile {
+
+    /// Rezoom this tile into a target tile at a different zoom level.
+    ///
+    /// Works for both overzooming (target `z` > source `z`) and underzooming
+    /// (target `z` < source `z`). The target must be an ancestor or descendant
+    /// of this tile; otherwise `nil` is returned.
+    ///
+    /// Features are copied in geographic coordinates — clipping to the target
+    /// tile's bounding box (plus an optional buffer) happens at encode time
+    /// when the caller invokes ``mvtData(options:)``, ``writeMVT(to:options:)``,
+    /// or ``toGeoJson(options:)``.
+    ///
+    /// - Parameters:
+    ///   - targetX: The target tile's x coordinate.
+    ///   - targetY: The target tile's y coordinate.
+    ///   - targetZ: The target tile's zoom level.
+    /// - Returns: A new `VectorTile` at the target coordinates containing this
+    ///   tile's features, or `nil` if the target is not an ancestor or
+    ///   descendant of this tile.
+    public func rezoom(
+        toTargetX targetX: Int,
+        targetY: Int,
+        targetZ: Int
+    ) -> VectorTile? {
+        let source = MapTile(x: x, y: y, z: z)
+        let target = MapTile(x: targetX, y: targetY, z: targetZ)
+
+        guard source.isRelated(to: target) else {
+            (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Target \(targetZ)/\(targetX)/\(targetY) is not an ancestor or descendant")
+            return nil
+        }
+
+        guard var result = VectorTile(
+            x: targetX,
+            y: targetY,
+            z: targetZ,
+            projection: projection,
+            logger: logger ?? VectorTile.logger)
+        else {
+            return nil
+        }
+
+        for layerName in layerNames {
+            let features = self.features(for: layerName)
+            guard features.isNotEmpty else { continue }
+            result.appendFeatures(features, to: layerName)
+        }
+
+        return result
+    }
+
+    /// Rezoom multiple source tiles into a single target tile.
+    ///
+    /// Each source tile is rezoomed to the target coordinates via
+    /// ``rezoom(toTargetX:targetY:targetZ:)`` and the results are merged.
+    /// Sources that are not ancestors or descendants of the target are
+    /// silently skipped (the result tile may still contain features from
+    /// valid sources).
+    ///
+    /// - Parameters:
+    ///   - sources: The source tiles (may be at different zoom levels).
+    ///     Each must be an ancestor or descendant of the target.
+    ///   - targetX: The target tile's x coordinate.
+    ///   - targetY: The target tile's y coordinate.
+    ///   - targetZ: The target tile's zoom level.
+    /// - Returns: A rezoomed `VectorTile` at the target coordinates. The
+    ///   tile may be empty if no sources were valid ancestors/descendants.
+    public static func rezoom(
+        _ sources: [VectorTile],
+        toTargetX targetX: Int,
+        targetY: Int,
+        targetZ: Int
+    ) -> VectorTile {
+        let target = MapTile(x: targetX, y: targetY, z: targetZ)
+
+        // Use the projection from the first valid source, or default to
+        // EPSG:4326 if no sources are valid.
+        var projection: Projection = .epsg4326
+        for source in sources {
+            if source.mapTile.isRelated(to: target) {
+                projection = source.projection
+                break
+            }
+        }
+
+        guard var result = VectorTile(x: targetX, y: targetY, z: targetZ, projection: projection) else {
+            // Should never fail for valid coordinates
+            return VectorTile(x: 0, y: 0, z: 0, projection: projection)!
+        }
+
+        for source in sources {
+            guard let rezoomed = source.rezoom(toTargetX: targetX, targetY: targetY, targetZ: targetZ) else {
+                continue
+            }
+            result.merge(rezoomed, ignoreTileCoordinateMismatch: true)
+        }
+
+        return result
+    }
+
+}

--- a/Tests/MVTCLITests/RezoomCommandTests.swift
+++ b/Tests/MVTCLITests/RezoomCommandTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import GISTools
+import MVTTools
+import Testing
+
+struct RezoomCommandTests {
+
+    // MARK: - Helpers
+
+    /// Path to the real MVT test data tile at z=14/x=8716/y=8015.
+    private static let sourceMVT: String = {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("MVTToolsTests")
+            .appendingPathComponent("TestData")
+            .appendingPathComponent("14_8716_8015.vector.mvt")
+            .path
+    }()
+
+    // MARK: - Tests
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomOverzoom() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Overzoom z=14/8716/8015 → z=15/17432/16030 (NW child)
+        let outputFile = outputDir.appendingPathComponent("15_17432_16030.mvt")
+        let (_, _, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--target-z", "15", "--target-x", "17432", "--target-y", "16030",
+            "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: outputFile.path))
+
+        // Verify the output has features by running info on it
+        let infoOutput = try runCLI(args: ["info", outputFile.path])
+        #expect(infoOutput.contains("test") || infoOutput.contains("road") || infoOutput.contains("building") || infoOutput.contains("landuse"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomUnderzoom() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Underzoom z=14/8716/8015 → z=13/4358/4007 (parent)
+        let outputFile = outputDir.appendingPathComponent("13_4358_4007.mvt")
+        let (_, _, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--target-z", "13", "--target-x", "4358", "--target-y", "4007",
+            "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: outputFile.path))
+
+        let infoOutput = try runCLI(args: ["info", outputFile.path])
+        #expect(infoOutput.contains("road") || infoOutput.contains("building") || infoOutput.contains("landuse"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomStrictFails() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Non-ancestor: z=14/8716/8015 → z=15/0/0 (not a child)
+        let outputFile = outputDir.appendingPathComponent("15_0_0.mvt")
+        let (_, stderr, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--target-z", "15", "--target-x", "0", "--target-y", "0",
+            "--strict", "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode != 0)
+        #expect(stderr.contains("not an ancestor or descendant"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomNonStrictSkips() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Non-ancestor without --strict → should succeed with empty output
+        let outputFile = outputDir.appendingPathComponent("15_0_0.mvt")
+        let (stdout, _, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--target-z", "15", "--target-x", "0", "--target-y", "0",
+            "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode == 0)
+        // The output file should exist but be empty (0 features)
+        // The stdout/console output for MVT is binary, so just check the file exists
+        #expect(FileManager.default.fileExists(atPath: outputFile.path))
+        _ = stdout
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomInferTargetFromOutput() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // Output filename 15_17432_16030.mvt → infer target z=15, x=17432, y=16030
+        let outputFile = outputDir.appendingPathComponent("15_17432_16030.mvt")
+        let (_, _, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode == 0)
+        #expect(FileManager.default.fileExists(atPath: outputFile.path))
+
+        let infoOutput = try runCLI(args: ["info", outputFile.path])
+        #expect(infoOutput.contains("road") || infoOutput.contains("building") || infoOutput.contains("landuse"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomMissingTargetErrors() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        // No --target-x/y/z and output path has no tile coords
+        let outputFile = outputDir.appendingPathComponent("output.mvt")
+        let (_, stderr, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--output", outputFile.path, Self.sourceMVT,
+        ])
+
+        #expect(exitCode != 0)
+        #expect(stderr.contains("Target coordinates") || stderr.contains("z, x and y"))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func rezoomVerbose() throws {
+        let outputDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mvt_rezoom_out_\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: outputDir) }
+
+        let outputFile = outputDir.appendingPathComponent("15_17432_16030.mvt")
+        let (stdout, _, exitCode) = try runCLIWithStderr(args: [
+            "rezoom", "--output", outputFile.path, "--verbose", Self.sourceMVT,
+        ])
+
+        #expect(exitCode == 0)
+        #expect(stdout.contains("Target tile:"))
+        #expect(stdout.contains("Done."))
+    }
+
+}

--- a/Tests/MVTToolsTests/OverzoomTests.swift
+++ b/Tests/MVTToolsTests/OverzoomTests.swift
@@ -1,0 +1,352 @@
+#if canImport(CoreLocation)
+import CoreLocation
+#endif
+import Foundation
+import GISTools
+import struct GISTools.Polygon
+@testable import MVTTools
+import Testing
+
+struct OverzoomTests {
+
+    // MARK: - Helpers
+
+    /// Creates a tile at the given coordinates with two point features:
+    /// one in the NW quadrant of the tile, one in the SE quadrant.
+    private func makeSourceTile(
+        x: Int,
+        y: Int,
+        z: Int,
+        projection: Projection = .epsg4326
+    ) -> VectorTile {
+        var tile = VectorTile(x: x, y: y, z: z, projection: projection)!
+        let bbox = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg4326)
+        let centerLon = (bbox.southWest.longitude + bbox.northEast.longitude) / 2.0
+        let centerLat = (bbox.southWest.latitude + bbox.northEast.latitude) / 2.0
+        let quarterLon = (bbox.southWest.longitude + centerLon) / 2.0
+        let quarterLat = (bbox.southWest.latitude + centerLat) / 2.0
+        let threeQuarterLon = (centerLon + bbox.northEast.longitude) / 2.0
+        let threeQuarterLat = (centerLat + bbox.northEast.latitude) / 2.0
+
+        let nwPoint = Feature(
+            Point(Coordinate3D(latitude: threeQuarterLat, longitude: quarterLon)),
+            properties: ["name": "nw"])
+
+        let sePoint = Feature(
+            Point(Coordinate3D(latitude: quarterLat, longitude: threeQuarterLon)),
+            properties: ["name": "se"])
+
+        tile.setFeatures([nwPoint, sePoint], for: "test")
+        return tile
+    }
+
+    // MARK: - Ancestry (delegates to MapTile.isRelated)
+
+    @Test
+    func isRelatedSameZoom() {
+        let tile = MapTile(x: 1, y: 1, z: 2)
+        #expect(tile.isRelated(to: tile))
+        #expect(!tile.isRelated(to: MapTile(x: 2, y: 2, z: 2)))
+    }
+
+    @Test
+    func isRelatedOverzoom() {
+        let source = MapTile(x: 1, y: 1, z: 2)
+        // Children of 2/1/1 at z=3: (2,2), (3,2), (2,3), (3,3)
+        #expect(source.isRelated(to: MapTile(x: 2, y: 2, z: 3)))
+        #expect(source.isRelated(to: MapTile(x: 3, y: 3, z: 3)))
+        // Grandchild at z=4 (4,4 is child of 3,2 which is child of 2,1)
+        #expect(source.isRelated(to: MapTile(x: 4, y: 4, z: 4)))
+        // 7,7 at z=4 is also a grandchild: 7>>1=3, 3>>1=1 → child of 2/1/1
+        #expect(source.isRelated(to: MapTile(x: 7, y: 7, z: 4)))
+        // Not a descendant
+        #expect(!source.isRelated(to: MapTile(x: 0, y: 0, z: 3)))
+        #expect(!source.isRelated(to: MapTile(x: 0, y: 0, z: 4)))
+    }
+
+    @Test
+    func isRelatedUnderzoom() {
+        let source = MapTile(x: 2, y: 2, z: 3)
+        let target = MapTile(x: 1, y: 1, z: 2)
+        #expect(source.isRelated(to: target))
+
+        // Source at z=4, target at z=2
+        let sourceDeep = MapTile(x: 4, y: 4, z: 4)
+        #expect(sourceDeep.isRelated(to: target))
+
+        // Not an ancestor
+        #expect(!MapTile(x: 0, y: 0, z: 3).isRelated(to: target))
+    }
+
+    // MARK: - Overzoom
+
+    @Test
+    func overzoomByOne() throws {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        // Overzoom to NW child: z=3, x=2, y=2
+        let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
+
+        #expect(result.z == 3)
+        #expect(result.x == 2)
+        #expect(result.y == 2)
+        #expect(result.projection == source.projection)
+
+        // Encode to MVT (which clips) and decode to check features
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 2, y: 2, z: 3))
+
+        let features = decoded.features(for: "test")
+        // The NW point should be in this child, the SE point should be clipped
+        let names = Set(features.compactMap { $0.properties["name"] as? String })
+        #expect(names.contains("nw"))
+        #expect(!names.contains("se"))
+    }
+
+    @Test
+    func overzoomByTwo() throws {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        // Overzoom to a grandchild at z=4
+        // Children of 2/1/1: z=3 → (2,2), (3,2), (2,3), (3,3)
+        // Children of 3/2/2: z=4 → (4,4), (5,4), (4,5), (5,5)
+        let result = try #require(source.rezoom(toTargetX: 4, targetY: 4, targetZ: 4))
+
+        #expect(result.z == 4)
+        #expect(result.x == 4)
+        #expect(result.y == 4)
+
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 4, y: 4, z: 4))
+
+        let features = decoded.features(for: "test")
+        // The NW point might be in this grandchild, depending on exact position
+        // The important thing is the SE point is definitely not here
+        let names = Set(features.compactMap { $0.properties["name"] as? String })
+        #expect(!names.contains("se"))
+    }
+
+    @Test
+    func overzoomNonAncestorReturnsNil() {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        // z=3/x=0/y=0 is NOT a child of z=2/x=1/y=1
+        let result = source.rezoom(toTargetX: 0, targetY: 0, targetZ: 3)
+        #expect(result == nil)
+    }
+
+    // MARK: - Underzoom
+
+    @Test
+    func underzoomByOne() throws {
+        // Source at z=3/x=2/y=2 (a child of z=2/x=1/y=1)
+        let source = makeSourceTile(x: 2, y: 2, z: 3)
+        let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
+
+        #expect(result.z == 2)
+        #expect(result.x == 1)
+        #expect(result.y == 1)
+
+        // Encode and decode — all features from the child should be in the parent
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 1, y: 1, z: 2))
+
+        let features = decoded.features(for: "test")
+        let names = Set(features.compactMap { $0.properties["name"] as? String })
+        // Both features should be retained (they're within the parent tile)
+        #expect(names.contains("nw"))
+        #expect(names.contains("se"))
+    }
+
+    @Test
+    func underzoomMultipleChildren() throws {
+        // Create all 4 children of z=2/x=1/y=1 at z=3
+        let children: [VectorTile] = [
+            makeSourceTile(x: 2, y: 2, z: 3),
+            makeSourceTile(x: 3, y: 2, z: 3),
+            makeSourceTile(x: 2, y: 3, z: 3),
+            makeSourceTile(x: 3, y: 3, z: 3),
+        ]
+
+        // Underzoom all 4 into their parent at z=2/x=1/y=1
+        let result = VectorTile.rezoom(children, toTargetX: 1, targetY: 1, targetZ: 2)
+
+        #expect(result.z == 2)
+        #expect(result.x == 1)
+        #expect(result.y == 1)
+
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 1, y: 1, z: 2))
+
+        let features = decoded.features(for: "test")
+        // Each child contributed 2 features → 8 total
+        #expect(features.count == 8)
+    }
+
+    @Test
+    func underzoomNonAncestorReturnsNil() {
+        let source = makeSourceTile(x: 0, y: 0, z: 3)
+        // z=2/x=1/y=1 is NOT the parent of z=3/x=0/y=0
+        let result = source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2)
+        #expect(result == nil)
+    }
+
+    // MARK: - Same zoom (identity)
+
+    @Test
+    func rezoomSameZoom() throws {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
+
+        #expect(result.z == 2)
+        #expect(result.x == 1)
+        #expect(result.y == 1)
+
+        let features = result.features(for: "test")
+        #expect(features.count == 2)
+    }
+
+    @Test
+    func rezoomSameZoomDifferentTileReturnsNil() {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let result = source.rezoom(toTargetX: 2, targetY: 2, targetZ: 2)
+        #expect(result == nil)
+    }
+
+    // MARK: - All projections
+
+    @Test
+    func overzoomAllProjections() throws {
+        for projection in [Projection.epsg4326, .epsg3857, .epsg4978, .noSRID] {
+            let source = makeSourceTile(x: 1, y: 1, z: 2, projection: projection)
+            let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
+
+            #expect(result.projection == projection)
+            #expect(result.z == 3)
+            #expect(result.x == 2)
+            #expect(result.y == 2)
+
+            // Features should be present (pre-encoding)
+            let features = result.features(for: "test")
+            #expect(features.count == 2, "projection \(projection) should have 2 features")
+        }
+    }
+
+    @Test
+    func underzoomAllProjections() throws {
+        for projection in [Projection.epsg4326, .epsg3857, .epsg4978, .noSRID] {
+            let source = makeSourceTile(x: 2, y: 2, z: 3, projection: projection)
+            let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
+
+            #expect(result.projection == projection)
+            #expect(result.z == 2)
+
+            let features = result.features(for: "test")
+            #expect(features.count == 2, "projection \(projection) should have 2 features")
+        }
+    }
+
+    // MARK: - Round-trip MVT
+
+    @Test
+    func overzoomMvtRoundTrip() throws {
+        // Use the real test data tile
+        let mvtData = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
+        let source = try #require(VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14))
+
+        // Overzoom to z=15, NW child (x=17432, y=16030)
+        let result = try #require(source.rezoom(toTargetX: 17432, targetY: 16030, targetZ: 15))
+
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 17432, y: 16030, z: 15))
+
+        // Should have some layers with features (the NW quadrant of the original tile)
+        #expect(decoded.layerNames.isNotEmpty)
+        let totalFeatures = decoded.layerNames.reduce(0) { $0 + decoded.features(for: $1).count }
+        #expect(totalFeatures > 0)
+    }
+
+    @Test
+    func underzoomMvtRoundTrip() throws {
+        let mvtData = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
+        let source = try #require(VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14))
+
+        // Underzoom to z=13, parent (x=4358, y=4007)
+        let result = try #require(source.rezoom(toTargetX: 4358, targetY: 4007, targetZ: 13))
+
+        let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
+        let decoded = try #require(VectorTile(mvtData: data, x: 4358, y: 4007, z: 13))
+
+        // All features should be retained (the source is within the parent)
+        #expect(decoded.layerNames.isNotEmpty)
+        let totalFeatures = decoded.layerNames.reduce(0) { $0 + decoded.features(for: $1).count }
+        #expect(totalFeatures > 0)
+    }
+
+    // MARK: - Round-trip GeoJSON
+
+    @Test
+    func overzoomGeoJsonRoundTrip() throws {
+        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
+
+        let data = try #require(result.toGeoJson(options: .init(bufferSize: .extent(0))))
+
+        let fc = try #require(FeatureCollection(jsonData: data))
+        // Only the NW point should be in this child tile
+        #expect(fc.features.isNotEmpty)
+    }
+
+    @Test
+    func underzoomGeoJsonRoundTrip() throws {
+        let source = makeSourceTile(x: 2, y: 2, z: 3)
+        let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
+
+        let data = try #require(result.toGeoJson(options: .init(bufferSize: .extent(0))))
+
+        let fc = try #require(FeatureCollection(jsonData: data))
+        // Both features should be retained
+        #expect(fc.features.count == 2)
+    }
+
+    // MARK: - Static rezoom with mixed sources
+
+    @Test
+    func rezoomMixedSources() throws {
+        // Source at z=2 (ancestor of target z=3)
+        let sourceA = makeSourceTile(x: 1, y: 1, z: 2)
+        // Source at z=3 (same zoom as target, same tile → identity)
+        let sourceB = makeSourceTile(x: 2, y: 2, z: 3)
+        // Source at z=4 (descendant of target z=3)
+        let sourceC = makeSourceTile(x: 4, y: 4, z: 4)
+
+        let result = VectorTile.rezoom(
+            [sourceA, sourceB, sourceC],
+            toTargetX: 2,
+            targetY: 2,
+            targetZ: 3)
+
+        #expect(result.z == 3)
+        #expect(result.x == 2)
+        #expect(result.y == 2)
+
+        // All three sources are valid ancestors/descendants of z=3/x=2/y=2
+        // Each contributes 2 features → 6 total
+        let features = result.features(for: "test")
+        #expect(features.count == 6)
+    }
+
+    @Test
+    func rezoomSkipsInvalidSources() throws {
+        let validSource = makeSourceTile(x: 1, y: 1, z: 2)
+        let invalidSource = makeSourceTile(x: 0, y: 0, z: 2) // not an ancestor of 3/2/2
+
+        let result = VectorTile.rezoom(
+            [validSource, invalidSource],
+            toTargetX: 2,
+            targetY: 2,
+            targetZ: 3)
+
+        // Only the valid source contributes
+        let features = result.features(for: "test")
+        #expect(features.count == 2)
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds a new `mvt rezoom` CLI subcommand and library API for rezooming (overzooming or underzooming) source tiles into a single output tile at a target zoom level.

Closes #46.

## Usage

```
mvt rezoom [--target-z <z>] [--target-x <x>] [--target-y <y>] \
           [--output <file>] [--output-format <fmt>] \
           [--buffer-extents <n>] [--buffer-pixels <n>] \
           [--simplify-extents <n>] [--simplify-meters <n>] \
           [--layer <name>...] [--drop-layer <name>...] \
           [--force-overwrite] [--strict] [--verbose] \
           <source-tiles...>
```

### Examples

```
# Overzoom z=14 tile to z=15 child, infer target from output filename
mvt rezoom --output ./tiles/15_17432_16030.mvt source_14_8716_8015.mvt

# Underzoom with explicit target coordinates
mvt rezoom --target-z 13 --target-x 4358 --target-y 4007 \
    --output out.mvt source_14_8716_8015.mvt

# Strict mode: abort if any source is not an ancestor/descendant
mvt rezoom --target-z 15 --target-x 2 --target-y 2 --strict \
    --output out.mvt source.mvt
```

## How it works

Each source tile must be an ancestor or descendant of the target tile (validated via `MapTile.isRelated(to:)` from gis-tools 2.0.7). Features are copied in geographic coordinates; clipping to the target tile's bounding box (+ optional buffer) happens at encode time via the existing `MVTEncoder`/`MLTEncoder` projection and clipping pipeline — no manual coordinate scaling needed.

- **Overzoom** (source z < target z): features outside the target child tile are clipped away.
- **Underzoom** (source z > target z): all child features are retained within the larger parent tile.
- **Same zoom** (identity): features pass through unchanged.

## Library API

```swift
// Rezoom a single tile
let result = source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3)

// Rezoom multiple sources into one target
let result = VectorTile.rezoom([sourceA, sourceB], toTargetX: 2, targetY: 2, targetZ: 3)
```

## CLI behavior

- **Target coordinates**: specified with `--target-x/y/z` or inferred from the `--output` file path (e.g. `15_17432_16030.mvt` or `15/17432/16030.mvt`).
- **`--strict`**: aborts with an error if any source is not an ancestor/descendant of the target. Without `--strict`, invalid sources are silently skipped.
- Supports all input/output formats (MVT, MLT, GeoJSON, GPX, Shapefile, GeoPackage) via the existing `TileFormat` loader and shared `CLI.writeTile` helper.

## Refactoring

Extracted the duplicated `writeTile` method from `MergeOptions` into a shared `CLI.writeTile` in `Sources/MVTCLI/WriteTile.swift`, used by both `Merge`/`Import`/`Export` and `Rezoom`.

## Files changed

- **`Sources/MVTTools/Overzoom.swift`** (new) — `VectorTile.rezoom()` instance + static methods
- **`Sources/MVTCLI/Rezoom.swift`** (new) — `CLI.Rezoom` subcommand
- **`Sources/MVTCLI/WriteTile.swift`** (new) — shared `CLI.writeTile` helper
- **`Sources/MVTCLI/CLI.swift`** — register `Rezoom.self`
- **`Sources/MVTCLI/MergeOptions.swift`** — use shared `CLI.writeTile`
- **`Package.swift`** — update gis-tools to 2.0.7
- **`Tests/MVTToolsTests/OverzoomTests.swift`** (new) — 19 library tests
- **`Tests/MVTCLITests/RezoomCommandTests.swift`** (new) — 7 CLI tests

## Test plan

- [x] `swift build` — clean, no warnings
- [x] `swift test --filter OverzoomTests` — 19/19 pass
- [x] `swift test --filter RezoomCommandTests` — 7/7 pass
- [x] `swift test` — 224/224 pass across 32 suites
- [x] `swift run mvt rezoom --help` — verified
- [x] Manual smoke tests: overzoom, underzoom, strict/non-strict, target inference