### PR TITLE
Disable FSST in MLT encoder and update gis-tools to 2.2.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c87d588f6b432d885f91900078c752face71229bd0424ed360a3df8c7fbdcf9e",
+  "originHash" : "27a6e37c02c3bcc8f04e30e291bc44466dc8ebcdd4f75cac02e68ed88036a091",
   "pins" : [
     {
       "identity" : "gis-tools",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Outdooractive/gis-tools",
       "state" : {
-        "revision" : "59671c24b1f79e1eefa090862fd02011c3ab4dc3",
-        "version" : "2.2.0"
+        "revision" : "15aac3d2565498ef5555010a8528c8e95a626f09",
+        "version" : "2.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             targets: ["MVTTools"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Outdooractive/gis-tools", from: "2.2.0"),
+        .package(url: "https://github.com/Outdooractive/gis-tools", from: "2.2.1"),
         .package(url: "https://github.com/Outdooractive/gis-tools-geopackage", from: "1.0.2"),
         .package(url: "https://github.com/Outdooractive/gis-tools-gpx", from: "1.0.4"),
         .package(url: "https://github.com/Outdooractive/gis-tools-fit", from: "1.0.0"),

--- a/Sources/CMLT/Bridge.cpp
+++ b/Sources/CMLT/Bridge.cpp
@@ -780,7 +780,15 @@ uint8_t* mlt_encoder_finish(
         state->currentFeatures.clear();
         state->currentLayerName.clear();
     }
-    auto result = state->encoder.encode(state->layers, mlt::EncoderConfig::with([](auto& c) { c.useFsst = true; }));
+    // FSST string compression must stay disabled here. The C++ MLT encoder
+    // trains its own FSST dictionary, which is binary-incompatible with the
+    // Rust/WASM FSST decoder used by maplibre-gl-js. With FSST enabled,
+    // string properties (e.g. "name_en", "type") are corrupted on the JS side
+    // in a content-dependent way, silently dropping features whose style
+    // filters compare those strings. Do NOT re-enable this setting without
+    // first verifying round-trip decoding against the maplibre-gl-js WASM
+    // decoder across a representative set of tiles.
+    auto result = state->encoder.encode(state->layers, mlt::EncoderConfig::with([](auto& c) { c.useFsst = false; }));
     auto* buffer = static_cast<uint8_t*>(std::malloc(result.size()));
     std::memcpy(buffer, result.data(), result.size());
     *outLength = result.size();


### PR DESCRIPTION
## Changes

### Disable FSST in MLT encoder

FSST string compression was re-enabled in `b0efa5f`, but the C++ FSST encoder remains **binary-incompatible** with the Rust/WASM FSST decoder used by maplibre-gl-js.

The corruption is **content-dependent**: tiles whose string corpus triggers a bad FSST dictionary silently drop features whose style filters compare string properties. The mvt-tools Swift decoder reads both fine because it uses the same C++ encoder's dictionary format.

This re-disables FSST (as `e20ad29` originally did) with a comment explaining why it must not be re-enabled without verifying round-trip decoding against the maplibre-gl-js WASM decoder across a representative set of tiles. String data is still encoded with shared dictionaries and delta/RLE integer encoding, so tile sizes are barely affected.
