### PR TITLE
Replace failable init? with throwing init across all Coders

### DIFF
--- a/Sources/MVTCLI/Dump.swift
+++ b/Sources/MVTCLI/Dump.swift
@@ -80,8 +80,6 @@ extension CLI {
                 layerProperty: disableInputLayerProperty ? nil : propertyName,
                 logger: options.verbose ? CLI.logger : nil)
 
-            guard let tile else { throw CLIError("Failed to parse the resource at '\(path)'") }
-
             if options.verbose {
                 print("Dumping \(format) tile '\(url.lastPathComponent)' [\(tile.x),\(tile.y)]@\(tile.z)")
 

--- a/Sources/MVTCLI/Info.swift
+++ b/Sources/MVTCLI/Info.swift
@@ -56,14 +56,14 @@ extension CLI {
             // Fast path: tileInfo works directly on MVT data
             var layers: [VectorTile.LayerInfo]?
             if case .mvt = format,
-               let info = VectorTile.tileInfo(at: url)
+               let info = try VectorTile.tileInfo(at: url)
             {
                 layers = info
             }
-            else if let tile = try await format.loadTile(
-                from: url,
-                logger: options.verbose ? CLI.logger : nil)
-            {
+            else {
+                let tile = try await format.loadTile(
+                    from: url,
+                    logger: options.verbose ? CLI.logger : nil)
                 layers = tile.tileInfo()
             }
 

--- a/Sources/MVTCLI/MergeOptions.swift
+++ b/Sources/MVTCLI/MergeOptions.swift
@@ -148,17 +148,14 @@ extension CLI.MergeOptions {
            (try? outputUrl.checkResourceIsReachable()) ?? false
         {
             let existingFormat = TileFormat(url: outputUrl) ?? resolvedOutputFormat
-            if let loadedTile = try await existingFormat.loadTile(
+            tile = try? await existingFormat.loadTile(
                 from: outputUrl,
                 logger: cliOptions.verbose ? CLI.logger : nil)
-            {
-                tile = loadedTile
-            }
         }
 
         // Create an empty tile if nothing was loaded yet
         if tile == nil {
-            tile = VectorTile(
+            tile = try VectorTile(
                 x: x ?? 0,
                 y: y ?? 0,
                 z: z ?? 0,
@@ -222,12 +219,11 @@ extension CLI.MergeOptions {
             ? nil
             : layerAllowlist
 
-            guard var otherTile = try await inputFormat.loadTile(
+            var otherTile = try await inputFormat.loadTile(
                 from: otherUrl,
                 layerAllowlist: effectiveAllowlist,
                 layerProperty: mergeOptions.disableInputLayerProperty ? nil : mergeOptions.propertyName,
                 logger: cliOptions.verbose ? CLI.logger : nil)
-            else { throw CLIError("Failed to parse the tile at '\(path)'") }
 
             if let layerDenylist {
                 for droppedLayer in layerDenylist {

--- a/Sources/MVTCLI/Query.swift
+++ b/Sources/MVTCLI/Query.swift
@@ -144,12 +144,11 @@ extension CLI {
                 ? nil
                 : layerAllowlist
 
-            guard var tile = try await format.loadTile(
+            var tile = try await format.loadTile(
                 from: url,
                 layerAllowlist: effectiveAllowlist,
                 layerProperty: disableInputLayerProperty ? nil : propertyName,
                 logger: options.verbose ? CLI.logger : nil)
-            else { throw CLIError("Failed to parse the resource at '\(path)'") }
 
             if let layerDenylist {
                 for droppedLayer in layerDenylist {

--- a/Sources/MVTCLI/Rezoom.swift
+++ b/Sources/MVTCLI/Rezoom.swift
@@ -198,12 +198,11 @@ extension CLI {
                     ? nil
                     : layerAllowlist
 
-                guard var sourceTile = try await inputFormat.loadTile(
+                var sourceTile = try await inputFormat.loadTile(
                     from: sourceUrl,
                     layerAllowlist: effectiveAllowlist,
                     layerProperty: disableInputLayerProperty ? nil : propertyName,
                     logger: options.verbose ? CLI.logger : nil)
-                else { throw CLIError("Failed to parse the tile at '\(path)'") }
 
                 if let layerDenylist {
                     for droppedLayer in layerDenylist {
@@ -228,7 +227,7 @@ extension CLI {
             }
 
             // 4. Rezoom
-            let result = VectorTile.rezoom(
+            let result = try VectorTile.rezoom(
                 loadedSources,
                 toTargetX: targetXYZ.x,
                 targetY: targetXYZ.y,

--- a/Sources/MVTCLI/TileFormat.swift
+++ b/Sources/MVTCLI/TileFormat.swift
@@ -76,52 +76,53 @@ extension TileFormat {
     ///   - layerProperty: Property name used for layer routing (GeoJSON/GPX).
     ///   - geopackageTable: When set, only this table is loaded from a GeoPackage.
     ///   - logger: Optional logger instance.
-    /// - Returns: A loaded tile, or `nil` if parsing failed.
+    /// - Returns: A loaded tile.
+    /// - Throws: ``VectorTileError`` or ``GeoPackageError``.
     func loadTile(
         from url: URL,
         layerAllowlist: [String]? = nil,
         layerProperty: String? = VectorTile.defaultLayerPropertyName,
         geopackageTable: String? = nil,
         logger: Logger? = nil
-    ) async throws -> VectorTile? {
+    ) async throws -> VectorTile {
         switch self {
         case .mvt(let x, let y, let z):
-            return VectorTile(
+            return try VectorTile(
                 contentsOfMVT: url,
                 x: x, y: y, z: z,
                 layerAllowlist: layerAllowlist,
                 logger: logger)
 
         case .mlt(let x, let y, let z):
-            return VectorTile(
+            return try VectorTile(
                 contentsOfMLT: url,
                 x: x, y: y, z: z,
                 layerAllowlist: layerAllowlist,
                 logger: logger)
 
         case .geoJson(let defaultLayerProperty):
-            return VectorTile(
+            return try VectorTile(
                 contentsOfGeoJson: url,
                 layerProperty: layerProperty ?? defaultLayerProperty,
                 layerAllowlist: layerAllowlist,
                 logger: logger)
 
         case .fit:
-            return VectorTile(
+            return try VectorTile(
                 contentsOfFIT: url,
                 layerProperty: layerProperty,
                 layerAllowlist: layerAllowlist,
                 logger: logger)
 
         case .gpx:
-            return VectorTile(
+            return try VectorTile(
                 contentsOfGPX: url,
                 layerProperty: layerProperty,
                 layerAllowlist: layerAllowlist,
                 logger: logger)
 
         case .shapefile:
-            return VectorTile(
+            return try VectorTile(
                 shapefile: url,
                 logger: logger)
 

--- a/Sources/MVTTools/Coders/FIT/VectorTile+FIT.swift
+++ b/Sources/MVTTools/Coders/FIT/VectorTile+FIT.swift
@@ -20,17 +20,26 @@ extension VectorTile {
     ///       When `nil`, features are imported as-is from the FIT data.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance.
-    /// - Returns: `nil` when the FIT data cannot be parsed or the tile coordinates are invalid.
-    public init?(
+    /// - Throws: ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         fitData data: Data,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let featureCollection = FeatureCollection(fitData: data),
-              let fcBoundingBox = featureCollection.calculateBoundingBox()
-        else { return nil }
+    ) throws {
+        guard let featureCollection = FeatureCollection(fitData: data) else {
+            throw VectorTileError.parseFailed(
+                format: "FIT",
+                reason: "unable to parse FeatureCollection from data")
+        }
+        guard let fcBoundingBox = featureCollection.calculateBoundingBox() else {
+            throw VectorTileError.parseFailed(
+                format: "FIT",
+                reason: "unable to calculate bounding box (empty collection)")
+        }
 
         let tile = MapTile(boundingBox: fcBoundingBox)
         self.x = tile.x
@@ -39,13 +48,14 @@ extension VectorTile {
 
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
 
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.projection = .epsg4326
@@ -104,19 +114,28 @@ extension VectorTile {
     ///       When `nil`, features are imported as-is from the FIT data.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance.
-    /// - Returns: `nil` when the file cannot be read or the data cannot be parsed.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         contentsOfFIT url: URL,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let data = try? Data(contentsOf: url) else {
-            (logger ?? VectorTile.logger)?.warning("Failed to load FIT from \(url)")
-            return nil
+    ) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
         }
-        self.init(
+        catch {
+            (logger ?? VectorTile.logger)?.warning("Failed to load FIT from \(url)")
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
+        try self.init(
             fitData: data,
             indexed: sortOption,
             layerProperty: layerProperty,

--- a/Sources/MVTTools/Coders/GPX/VectorTile+GPX.swift
+++ b/Sources/MVTTools/Coders/GPX/VectorTile+GPX.swift
@@ -21,17 +21,26 @@ extension VectorTile {
     ///       (`"gpx_type"` → `"wpt"`, `"rte"`, `"trk"`).
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance.
-    /// - Returns: `nil` when the GPX data cannot be parsed or the tile coordinates are invalid.
-    public init?(
+    /// - Throws: ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         gpxData data: Data,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = "gpx_type",
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let featureCollection = FeatureCollection(gpxData: data),
-              let fcBoundingBox = featureCollection.calculateBoundingBox()
-        else { return nil }
+    ) throws {
+        guard let featureCollection = FeatureCollection(gpxData: data) else {
+            throw VectorTileError.parseFailed(
+                format: "GPX",
+                reason: "unable to parse FeatureCollection from data")
+        }
+        guard let fcBoundingBox = featureCollection.calculateBoundingBox() else {
+            throw VectorTileError.parseFailed(
+                format: "GPX",
+                reason: "unable to calculate bounding box (empty collection)")
+        }
 
         let tile = MapTile(boundingBox: fcBoundingBox)
         self.x = tile.x
@@ -40,13 +49,14 @@ extension VectorTile {
 
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
 
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.projection = .epsg4326
@@ -85,19 +95,28 @@ extension VectorTile {
     ///       When `nil`, features are split by their GPX element type (`"gpx_type"`).
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance.
-    /// - Returns: `nil` when the file cannot be read or the data cannot be parsed.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         contentsOfGPX url: URL,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = "gpx_type",
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let data = try? Data(contentsOf: url) else {
-            (logger ?? VectorTile.logger)?.warning("Failed to load GPX from \(url)")
-            return nil
+    ) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
         }
-        self.init(
+        catch {
+            (logger ?? VectorTile.logger)?.warning("Failed to load GPX from \(url)")
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
+        try self.init(
             gpxData: data,
             indexed: sortOption,
             layerProperty: layerProperty,

--- a/Sources/MVTTools/Coders/GeoJSON/VectorTile+GeoJSON.swift
+++ b/Sources/MVTTools/Coders/GeoJSON/VectorTile+GeoJSON.swift
@@ -21,17 +21,26 @@ extension VectorTile {
     ///       Defaults to `VectorTile.defaultLayerPropertyName`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the GeoJSON data cannot be parsed or the tile coordinates are invalid.
-    public init?(
+    /// - Throws: ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         geoJsonData data: Data,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = VectorTile.defaultLayerPropertyName,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let featureCollection = FeatureCollection(jsonData: data),
-              let fcBoundingBox = featureCollection.calculateBoundingBox()
-        else { return nil }
+    ) throws {
+        guard let featureCollection = FeatureCollection(jsonData: data) else {
+            throw VectorTileError.parseFailed(
+                format: "GeoJSON",
+                reason: "unable to parse FeatureCollection from data")
+        }
+        guard let fcBoundingBox = featureCollection.calculateBoundingBox() else {
+            throw VectorTileError.parseFailed(
+                format: "GeoJSON",
+                reason: "unable to calculate bounding box (empty collection)")
+        }
 
         // Find the minimal tile for the GeoJSON
         let tile = MapTile(boundingBox: fcBoundingBox)
@@ -41,13 +50,14 @@ extension VectorTile {
 
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
 
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.projection = .epsg4326
@@ -84,20 +94,29 @@ extension VectorTile {
     ///       Defaults to `VectorTile.defaultLayerPropertyName`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the file cannot be read or the GeoJSON data cannot be parsed.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         contentsOfGeoJson url: URL,
         indexed sortOption: RTreeSortOption? = nil,
         layerProperty: String? = VectorTile.defaultLayerPropertyName,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let data = try? Data(contentsOf: url) else {
+    ) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        }
+        catch {
             (logger ?? VectorTile.logger)?.warning("Failed to import GeoJSON from \(url)")
-            return nil
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
         }
 
-        self.init(
+        try self.init(
             geoJsonData: data,
             indexed: sortOption,
             layerProperty: layerProperty,

--- a/Sources/MVTTools/Coders/MLT/VectorTile+MLT.swift
+++ b/Sources/MVTTools/Coders/MLT/VectorTile+MLT.swift
@@ -17,8 +17,10 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid, out of bounds, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         mltData data: Data,
         x: Int,
         y: Int,
@@ -27,15 +29,16 @@ extension VectorTile {
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
+    ) throws {
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.x = x
@@ -53,13 +56,20 @@ extension VectorTile {
             self.boundingBox = MapTile(x: x, y: y, z: z).boundingBox(projection: projection)
         }
 
-        guard let parsedLayers = try? MLTDecoder.decode(
-            from: data, x: x, y: y, z: z,
-            projection: projection,
-            layerAllowlist: layerAllowlist.map(Set.init),
-            calculateBoundingBox: true,
-            logger: logger)
-        else { return nil }
+        let parsedLayers: [String: VectorTile.LayerContainer]
+        do {
+            parsedLayers = try MLTDecoder.decode(
+                from: data, x: x, y: y, z: z,
+                projection: projection,
+                layerAllowlist: layerAllowlist.map(Set.init),
+                calculateBoundingBox: true,
+                logger: logger)
+        }
+        catch {
+            throw VectorTileError.parseFailed(
+                format: "MLT",
+                reason: error.localizedDescription)
+        }
 
         self.layers = parsedLayers
         self.layerNames = Array(layers.keys)
@@ -79,16 +89,18 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid, out of bounds, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         mltData data: Data,
         tile: MapTile,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        self.init(
+    ) throws {
+        try self.init(
             mltData: data,
             x: tile.x,
             y: tile.y,
@@ -110,8 +122,11 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the file cannot be read, coordinates are invalid, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         contentsOfMLT url: URL,
         x: Int,
         y: Int,
@@ -120,12 +135,18 @@ extension VectorTile {
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let data = try? Data(contentsOf: url) else {
-            (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Failed to load MLT tile from \(url)")
-            return nil
+    ) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
         }
-        self.init(
+        catch {
+            (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Failed to load MLT tile from \(url)")
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
+        try self.init(
             mltData: data,
             x: x,
             y: y,
@@ -145,16 +166,19 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the file cannot be read, coordinates are invalid, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         contentsOfMLT url: URL,
         tile: MapTile,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        self.init(
+    ) throws {
+        try self.init(
             contentsOfMLT: url,
             x: tile.x,
             y: tile.y,

--- a/Sources/MVTTools/Coders/MVT/VectorTile+MVT.swift
+++ b/Sources/MVTTools/Coders/MVT/VectorTile+MVT.swift
@@ -17,8 +17,10 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid, out of bounds, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         mvtData data: Data,
         x: Int,
         y: Int,
@@ -27,15 +29,16 @@ extension VectorTile {
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
+    ) throws {
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.x = x
@@ -59,7 +62,9 @@ extension VectorTile {
             layerAllowlist: layerAllowlist.map(Set.init),
             calculateBoundingBox: true,
             logger: logger)
-        else { return nil }
+        else {
+            throw VectorTileError.parseFailed(format: "MVT", reason: "protobuf deserialization failed")
+        }
 
         self.layers = parsedLayers
         self.layerNames = Array(layers.keys)
@@ -79,16 +84,18 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid, out of bounds, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         mvtData data: Data,
         tile: MapTile,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        self.init(
+    ) throws {
+        try self.init(
             mvtData: data,
             x: tile.x,
             y: tile.y,
@@ -110,8 +117,11 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the file cannot be read, coordinates are invalid, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         contentsOfMVT url: URL,
         x: Int,
         y: Int,
@@ -120,12 +130,18 @@ extension VectorTile {
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        guard let data = try? Data(contentsOf: url) else {
-            (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Failed to load vector tile from \(url)")
-            return nil
+    ) throws {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
         }
-        self.init(
+        catch {
+            (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Failed to load vector tile from \(url)")
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
+        try self.init(
             mvtData: data,
             x: x,
             y: y,
@@ -145,16 +161,19 @@ extension VectorTile {
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - layerAllowlist: An optional set of layer names to load. If `nil`, all layers are loaded.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the file cannot be read, coordinates are invalid, or decoding fails.
-    public init?(
+    /// - Throws: ``VectorTileError/fileReadFailed``,
+    ///   ``VectorTileError/invalidCoordinate``,
+    ///   ``VectorTileError/coordinateOutOfBounds``, or
+    ///   ``VectorTileError/parseFailed``.
+    public init(
         contentsOfMVT url: URL,
         tile: MapTile,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         layerAllowlist: [String]? = nil,
         logger: Logger? = nil
-    ) {
-        self.init(
+    ) throws {
+        try self.init(
             contentsOfMVT: url,
             x: tile.x,
             y: tile.y,

--- a/Sources/MVTTools/Coders/Shapefile/VectorTile+Shapefile.swift
+++ b/Sources/MVTTools/Coders/Shapefile/VectorTile+Shapefile.swift
@@ -17,19 +17,29 @@ extension VectorTile {
     ///   - layerName: The target layer name. When `nil`, the shapefile's filename is used.
     ///   - sortOption: An optional R-Tree sort option for spatial indexing.
     ///   - logger: An optional logger instance.
-    /// - Returns: `nil` when the file cannot be read or the tile coordinates are invalid.
-    public init?(
+    /// - Throws: ``VectorTileError/parseFailed``,
+    ///   ``VectorTileError/invalidCoordinate``, or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         shapefile url: URL,
         layerName: String? = nil,
         indexed sortOption: RTreeSortOption? = nil,
         logger: Logger? = nil
-    ) {
+    ) throws {
         guard let featureCollection = FeatureCollection(
             shapefile: url,
             calculateBoundingBox: true)
-        else { return nil }
+        else {
+            throw VectorTileError.parseFailed(
+                format: "Shapefile",
+                reason: "unable to read or parse shapefile at \(url.path)")
+        }
 
-        guard let fcBoundingBox = featureCollection.calculateBoundingBox() else { return nil }
+        guard let fcBoundingBox = featureCollection.calculateBoundingBox() else {
+            throw VectorTileError.parseFailed(
+                format: "Shapefile",
+                reason: "unable to calculate bounding box (empty collection)")
+        }
 
         let tile = MapTile(boundingBox: fcBoundingBox)
         self.x = tile.x
@@ -38,13 +48,14 @@ extension VectorTile {
 
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
 
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.projection = featureCollection.projection

--- a/Sources/MVTTools/Info.swift
+++ b/Sources/MVTTools/Info.swift
@@ -44,8 +44,8 @@ extension VectorTile {
     ///
     /// - Parameter url: A file URL pointing to an MVT file on disk.
     /// - Returns: An array of layer name strings, or `nil` if the file could not be read or decoded.
-    public static func layerNames(at url: URL) -> [String]? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
+    public static func layerNames(at url: URL) throws -> [String]? {
+        let data = try Data(contentsOf: url)
         return layerNames(from: data)
     }
 
@@ -162,8 +162,8 @@ extension VectorTile {
     ///
     /// - Parameter url: A file URL pointing to an MVT file on disk.
     /// - Returns: An array of ``LayerInfo`` values, one per layer, or `nil` if the file could not be read or decoded.
-    public static func tileInfo(at url: URL) -> [LayerInfo]? {
-        guard let data = try? Data(contentsOf: url) else { return nil }
+    public static func tileInfo(at url: URL) throws -> [LayerInfo]? {
+        let data = try Data(contentsOf: url)
         return tileInfo(from: data)
     }
 

--- a/Sources/MVTTools/Info.swift
+++ b/Sources/MVTTools/Info.swift
@@ -43,9 +43,18 @@ extension VectorTile {
     /// Load a tile from the given file URL and return the names of every layer it contains.
     ///
     /// - Parameter url: A file URL pointing to an MVT file on disk.
-    /// - Returns: An array of layer name strings, or `nil` if the file could not be read or decoded.
+    /// - Returns: An array of layer name strings, or `nil` if the data could not be decoded.
+    /// - Throws: ``VectorTileError/fileReadFailed`` if the file cannot be read.
     public static func layerNames(at url: URL) throws -> [String]? {
-        let data = try Data(contentsOf: url)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        }
+        catch {
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
         return layerNames(from: data)
     }
 
@@ -161,9 +170,18 @@ extension VectorTile {
     /// Load a tile from the given file URL and gather summary information about each of its layers.
     ///
     /// - Parameter url: A file URL pointing to an MVT file on disk.
-    /// - Returns: An array of ``LayerInfo`` values, one per layer, or `nil` if the file could not be read or decoded.
+    /// - Returns: An array of ``LayerInfo`` values, one per layer, or `nil` if the data could not be decoded.
+    /// - Throws: ``VectorTileError/fileReadFailed`` if the file cannot be read.
     public static func tileInfo(at url: URL) throws -> [LayerInfo]? {
-        let data = try Data(contentsOf: url)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        }
+        catch {
+            throw VectorTileError.fileReadFailed(
+                url: url,
+                reason: error.localizedDescription)
+        }
         return tileInfo(from: data)
     }
 

--- a/Sources/MVTTools/Info.swift
+++ b/Sources/MVTTools/Info.swift
@@ -60,8 +60,8 @@ extension VectorTile {
 
     /// Gather summary information about the features in each layer of this tile.
     ///
-    /// - Returns: An array of ``LayerInfo`` values, one per layer, or `nil` if the tile has no layers.
-    public func tileInfo() -> [LayerInfo]? {
+    /// - Returns: An array of ``LayerInfo`` values, one per layer.
+    public func tileInfo() -> [LayerInfo] {
         var result: [LayerInfo] = []
 
         for (layerName, layerContainer) in layers {

--- a/Sources/MVTTools/Overzoom.swift
+++ b/Sources/MVTTools/Overzoom.swift
@@ -40,7 +40,7 @@ extension VectorTile {
             return nil
         }
 
-        guard var result = VectorTile(
+        guard var result = try? VectorTile(
             x: targetX,
             y: targetY,
             z: targetZ,
@@ -75,12 +75,13 @@ extension VectorTile {
     ///   - targetZ: The target tile's zoom level.
     /// - Returns: A rezoomed `VectorTile` at the target coordinates. The
     ///   tile may be empty if no sources were valid ancestors/descendants.
+    /// - Throws: ``VectorTileError`` if the target coordinates are invalid.
     public static func rezoom(
         _ sources: [VectorTile],
         toTargetX targetX: Int,
         targetY: Int,
         targetZ: Int
-    ) -> VectorTile {
+    ) throws -> VectorTile {
         let target = MapTile(x: targetX, y: targetY, z: targetZ)
 
         // Use the projection from the first valid source, or default to
@@ -93,10 +94,7 @@ extension VectorTile {
             }
         }
 
-        guard var result = VectorTile(x: targetX, y: targetY, z: targetZ, projection: projection) else {
-            // Should never fail for valid coordinates
-            return VectorTile(x: 0, y: 0, z: 0, projection: projection)!
-        }
+        var result = try VectorTile(x: targetX, y: targetY, z: targetZ, projection: projection)
 
         for source in sources {
             guard let rezoomed = source.rezoom(toTargetX: targetX, targetY: targetY, targetZ: targetZ) else {

--- a/Sources/MVTTools/VectorTile.swift
+++ b/Sources/MVTTools/VectorTile.swift
@@ -119,24 +119,26 @@ public struct VectorTile: Sendable {
     ///   - projection: The spatial projection for the tile. Defaults to `.epsg4326`.
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid or out of bounds.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate`` or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         x: Int,
         y: Int,
         z: Int,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         logger: Logger? = nil
-    ) {
+    ) throws {
         guard x >= 0, y >= 0, z >= 0 else {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Invalid tile coordinate")
-            return nil
+            throw VectorTileError.invalidCoordinate(x: x, y: y, z: z)
         }
 
         let maximumTileCoordinate = 1 << z
         if x >= maximumTileCoordinate || y >= maximumTileCoordinate {
             (logger ?? VectorTile.logger)?.warning("\(z)/\(x)/\(y): Tile coordinate outside bounds")
-            return nil
+            throw VectorTileError.coordinateOutOfBounds(
+                x: x, y: y, z: z, maxBound: maximumTileCoordinate)
         }
 
         self.x = x
@@ -171,14 +173,15 @@ public struct VectorTile: Sendable {
     ///   - projection: The spatial projection for the tile. Defaults to `.epsg4326`.
     ///   - sortOption: An optional R-Tree sort option for spatial indexing. Defaults to `nil`.
     ///   - logger: An optional logger instance. Defaults to `nil`.
-    /// - Returns: `nil` when the tile coordinates are invalid or out of bounds.
-    public init?(
+    /// - Throws: ``VectorTileError/invalidCoordinate`` or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public init(
         tile: MapTile,
         projection: Projection = .epsg4326,
         indexed sortOption: RTreeSortOption? = nil,
         logger: Logger? = nil
-    ) {
-        self.init(
+    ) throws {
+        try self.init(
             x: tile.x,
             y: tile.y,
             z: tile.z,
@@ -196,9 +199,11 @@ public struct VectorTile: Sendable {
     /// Creates a new tile by extracting the named layers from this tile.
     ///
     /// - Parameter layerNames: The layer names to extract into the new tile.
-    /// - Returns: A new `VectorTile` containing only the specified layers, or `nil` if creation fails.
-    public func extract(layerNames: [String]) -> VectorTile? {
-        guard var newTile = VectorTile(x: x, y: y, z: z, projection: projection) else { return nil }
+    /// - Returns: A new `VectorTile` containing only the specified layers.
+    /// - Throws: ``VectorTileError/invalidCoordinate`` or
+    ///   ``VectorTileError/coordinateOutOfBounds``.
+    public func extract(layerNames: [String]) throws -> VectorTile {
+        var newTile = try VectorTile(x: x, y: y, z: z, projection: projection)
 
         for name in layerNames {
             newTile.layers[name] = layers[name]

--- a/Sources/MVTTools/VectorTileError.swift
+++ b/Sources/MVTTools/VectorTileError.swift
@@ -1,0 +1,40 @@
+import Foundation
+import GISTools
+
+/// Errors thrown by ``VectorTile`` initializers when loading data or
+/// validating tile coordinates.
+public enum VectorTileError: Error, Equatable {
+
+    /// One or more tile coordinates are negative or invalid.
+    case invalidCoordinate(x: Int, y: Int, z: Int)
+
+    /// The tile coordinate exceeds the valid range for the zoom level.
+    case coordinateOutOfBounds(x: Int, y: Int, z: Int, maxBound: Int)
+
+    /// The file at `url` could not be read.
+    case fileReadFailed(url: URL, reason: String)
+
+    /// The data could not be parsed in the expected format.
+    case parseFailed(format: String, reason: String)
+
+}
+
+// MARK: - LocalizedError
+
+extension VectorTileError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidCoordinate(x, y, z):
+            "Invalid tile coordinate: z=\(z), x=\(x), y=\(y). Coordinates must be >= 0."
+        case let .coordinateOutOfBounds(x, y, z, maxBound):
+            "Tile coordinate out of bounds at zoom \(z): x=\(x), y=\(y). "
+            + "Maximum is \(maxBound - 1) (2^\(z) = \(maxBound))."
+        case let .fileReadFailed(url, reason):
+            "Failed to read \(url.absoluteString): \(reason)"
+        case let .parseFailed(format, reason):
+            "Failed to parse \(format) data: \(reason)"
+        }
+    }
+
+}

--- a/Tests/MVTCLITests/TestHelpers.swift
+++ b/Tests/MVTCLITests/TestHelpers.swift
@@ -211,7 +211,7 @@ func generateSmallShapefile() throws -> URL {
 
 func generateSmallGeoPackage() async throws -> URL {
     let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test_\(UUID().uuidString).gpkg")
-    var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+    var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
     tile.setFeatures([
         Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1), properties: ["name": "A"]),
     ], for: "layer_a")
@@ -224,7 +224,7 @@ func generateSmallGeoPackage() async throws -> URL {
 
 func generateSmallMlt(coord: Int = 0) throws -> URL {
     let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test_\(UUID().uuidString).mlt")
-    var tile = VectorTile(x: coord, y: coord, z: 0, projection: .epsg4326)!
+    var tile = try VectorTile(x: coord, y: coord, z: 0, projection: .epsg4326)
     tile.setFeatures([
         Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1), properties: ["name": "A"]),
     ], for: "test")
@@ -235,7 +235,7 @@ func generateSmallMlt(coord: Int = 0) throws -> URL {
 
 func generateSmallMvt(coord: Int = 0) throws -> URL {
     let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test_\(UUID().uuidString).mvt")
-    var tile = VectorTile(x: coord, y: coord, z: 0, projection: .epsg4326)!
+    var tile = try VectorTile(x: coord, y: coord, z: 0, projection: .epsg4326)
     tile.setFeatures([
         Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1), properties: ["name": "A"]),
     ], for: "test")

--- a/Tests/MVTToolsTests/FIT/FITCoderTests.swift
+++ b/Tests/MVTToolsTests/FIT/FITCoderTests.swift
@@ -60,9 +60,9 @@ struct VectorTileFITTests {
     @Test
     func fitDataInit() throws {
         let data = Self.makeSampleFitData()
-        let tile = try #require(VectorTile(
+        let tile = try VectorTile(
             fitData: data,
-            indexed: nil))
+            indexed: nil)
         #expect(tile.origin == .fit)
         #expect(tile.layers.isEmpty == false)
     }
@@ -70,7 +70,7 @@ struct VectorTileFITTests {
     @Test
     func fitContentsOfAndWrite() throws {
         let data = Self.makeSampleFitData()
-        let tile = try #require(VectorTile(fitData: data))
+        let tile = try VectorTile(fitData: data)
 
         let tempUrl = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("fit_\(UUID().uuidString).fit")
@@ -79,7 +79,7 @@ struct VectorTileFITTests {
         #expect(tile.writeFIT(to: tempUrl))
         #expect(FileManager.default.fileExists(atPath: tempUrl.path))
 
-        let readTile = try #require(VectorTile(contentsOfFIT: tempUrl))
+        let readTile = try VectorTile(contentsOfFIT: tempUrl)
         #expect(readTile.origin == .fit)
         #expect(readTile.layers.isEmpty == false)
     }
@@ -87,12 +87,12 @@ struct VectorTileFITTests {
     @Test
     func fitToFitDataRoundtrip() throws {
         let data = Self.makeSampleFitData()
-        let tile = try #require(VectorTile(fitData: data))
+        let tile = try VectorTile(fitData: data)
 
         let exported = try #require(tile.toFitData())
         #expect(exported.isEmpty == false)
 
-        let reimported = try #require(VectorTile(fitData: exported))
+        let reimported = try VectorTile(fitData: exported)
         #expect(reimported.origin == .fit)
         let reCount = reimported.layers.values.reduce(0) { $0 + $1.features.count }
         #expect(reCount > 0)
@@ -103,24 +103,24 @@ struct VectorTileFITTests {
     @Test
     func fitToGeoJsonRoundtrip() throws {
         let data = Self.makeSampleFitData()
-        let tile = try #require(VectorTile(fitData: data))
+        let tile = try VectorTile(fitData: data)
 
         let geojson = try #require(tile.toGeoJson())
         #expect(geojson.isEmpty == false)
 
-        let reimported = try #require(VectorTile(geoJsonData: geojson, indexed: nil))
+        let reimported = try VectorTile(geoJsonData: geojson, indexed: nil)
         #expect(reimported.layers.isEmpty == false)
     }
 
     @Test
     func fitToGpxRoundtrip() throws {
         let data = Self.makeSampleFitData()
-        let tile = try #require(VectorTile(fitData: data))
+        let tile = try VectorTile(fitData: data)
 
         let gpx = try #require(tile.toGpxData())
         #expect(gpx.isEmpty == false)
 
-        let reimported = try #require(VectorTile(gpxData: gpx, indexed: nil))
+        let reimported = try VectorTile(gpxData: gpx, indexed: nil)
         #expect(reimported.layers.isEmpty == false)
     }
 

--- a/Tests/MVTToolsTests/GPX/GPXCoderTests.swift
+++ b/Tests/MVTToolsTests/GPX/GPXCoderTests.swift
@@ -26,9 +26,9 @@ struct VectorTileGPXTests {
     @Test
     func gpxDataInit() throws {
         let data = try #require(Self.gpxWaypoints.data(using: .utf8))
-        let tile = try #require(VectorTile(
+        let tile = try VectorTile(
             gpxData: data,
-            indexed: nil))
+            indexed: nil)
         #expect(tile.origin == .gpx)
         #expect(tile.layers.keys.contains("wpt"),
                 "GPX features should be in a 'wpt' layer")
@@ -38,7 +38,7 @@ struct VectorTileGPXTests {
     @Test
     func gpxContentsOfAndWrite() throws {
         let data = try #require(Self.gpxWaypoints.data(using: .utf8))
-        let tile = try #require(VectorTile(gpxData: data))
+        let tile = try VectorTile(gpxData: data)
 
         let tempUrl = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("gpx_\(UUID().uuidString).gpx")
@@ -47,7 +47,7 @@ struct VectorTileGPXTests {
         #expect(tile.writeGPX(to: tempUrl))
         #expect(FileManager.default.fileExists(atPath: tempUrl.path))
 
-        let readTile = try #require(VectorTile(contentsOfGPX: tempUrl))
+        let readTile = try VectorTile(contentsOfGPX: tempUrl)
         #expect(readTile.origin == .gpx)
         #expect(readTile.layers.isEmpty == false)
     }
@@ -55,12 +55,12 @@ struct VectorTileGPXTests {
     @Test
     func gpxToGpxDataRoundtrip() throws {
         let data = try #require(Self.gpxWaypoints.data(using: .utf8))
-        let tile = try #require(VectorTile(gpxData: data))
+        let tile = try VectorTile(gpxData: data)
 
         let exported = try #require(tile.toGpxData())
         #expect(exported.isEmpty == false)
 
-        let reimported = try #require(VectorTile(gpxData: exported))
+        let reimported = try VectorTile(gpxData: exported)
         #expect(reimported.origin == .gpx)
         let reCount = reimported.layers.values.reduce(0) { $0 + $1.features.count }
         #expect(reCount == 2)

--- a/Tests/MVTToolsTests/GeoJSON/GeoJsonCoderTests.swift
+++ b/Tests/MVTToolsTests/GeoJSON/GeoJsonCoderTests.swift
@@ -12,7 +12,7 @@ struct GeoJsonFormatIOTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let allLayersJSONData = try #require(tile.toGeoJson(layerProperty: VectorTile.defaultLayerPropertyName))
         let allLayersFc = try #require(FeatureCollection(jsonData: allLayersJSONData))
@@ -32,11 +32,11 @@ struct GeoJsonFormatIOTests {
     @Test
     func geoJSONWithNull() throws {
         let fc = FeatureCollection(Feature(Point(Coordinate3D(latitude: 47.56, longitude: 10.22, m: 1234))))
-        var tile = try #require(VectorTile(x: 8657, y: 5725, z: 14))
+        var tile = try VectorTile(x: 8657, y: 5725, z: 14)
         tile.addGeoJson(geoJson: fc, layerName: "test")
 
         let data = try #require(tile.mvtData())
-        let decodedTile = try #require(VectorTile(mvtData: data, x: 8657, y: 5725, z: 14))
+        let decodedTile = try VectorTile(mvtData: data, x: 8657, y: 5725, z: 14)
         let decodedFc = try #require(decodedTile.features(for: "test").first)
         let decodedCoordinate = try #require(decodedFc.geometry.allCoordinates.first)
 
@@ -48,7 +48,7 @@ struct GeoJsonFormatIOTests {
     @Test
     func loadGeoJson() throws {
         let geoJsonData = try TestData.dataFromFile(name: "14_8716_8015.geojson")
-        let tile = try #require(VectorTile(geoJsonData: geoJsonData, layerProperty: nil))
+        let tile = try VectorTile(geoJsonData: geoJsonData, layerProperty: nil)
         #expect(tile.isEmpty == false)
         #expect(tile.origin == .geoJson)
 
@@ -63,14 +63,14 @@ struct GeoJsonFormatIOTests {
             .appendingPathComponent("test_write_geojson_\(UUID().uuidString).geojson")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.appendFeatures([feature], to: "test")
 
         let success = tile.writeGeoJson(to: tempUrl)
         #expect(success)
 
-        let readTile = try #require(VectorTile(contentsOfGeoJson: tempUrl, layerProperty: nil))
+        let readTile = try VectorTile(contentsOfGeoJson: tempUrl, layerProperty: nil)
         #expect(readTile.isEmpty == false)
     }
 

--- a/Tests/MVTToolsTests/GeoJsonTests.swift
+++ b/Tests/MVTToolsTests/GeoJsonTests.swift
@@ -9,7 +9,7 @@ struct AddSetGeoJsonTests {
     /// based on the property value, and respects the layer allow list.
     @Test
     func addGeoJsonWithLayerProperty() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         var feature1 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         feature1.setProperty("roads", for: "vt_layer")
@@ -28,7 +28,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `setGeoJson` replaces features in a layer but does not remove other layers.
     @Test
     func setGeoJsonReplacesContent() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         var feature1 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         feature1.setProperty("layer_a", for: "vt_layer")
@@ -46,7 +46,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `addGeoJson` with a layer allow list only imports the specified layers.
     @Test
     func addGeoJsonWithLayerAllowList() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         var feature1 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         feature1.setProperty("allowed_layer", for: "vt_layer")
@@ -63,7 +63,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `addGeoJson` without layer property puts all features into a default layer.
     @Test
     func addGeoJsonWithoutLayerProperty() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         let fc = FeatureCollection([feature])
@@ -76,7 +76,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `setGeoJson` without layer property replaces all features in the default layer.
     @Test
     func setGeoJsonWithoutLayerProperty() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         let feature1 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.addGeoJson(geoJson: FeatureCollection([feature1]), layerName: "test")
@@ -91,7 +91,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `addGeoJson` with explicit layer name targets the given layer.
     @Test
     func addGeoJsonWithExplicitLayerName() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.addGeoJson(geoJson: FeatureCollection([feature]), layerName: "custom_layer")
@@ -103,7 +103,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `addGeoJson` strips the routing property from features.
     @Test
     func addGeoJsonStripsRoutingProperty() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         var feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         feature.setProperty("roads", for: "vt_layer")
@@ -116,7 +116,7 @@ struct AddSetGeoJsonTests {
     /// Tests that `setGeoJson` strips the routing property from features.
     @Test
     func setGeoJsonStripsRoutingProperty() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
 
         var feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         feature.setProperty("roads", for: "vt_layer")

--- a/Tests/MVTToolsTests/GeoPackage/GeoPackageCoderTests.swift
+++ b/Tests/MVTToolsTests/GeoPackage/GeoPackageCoderTests.swift
@@ -14,7 +14,7 @@ struct VectorTileGeoPackageTests {
             .appendingPathComponent("gpkg_\(UUID().uuidString).gpkg")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         tile.setFeatures([point], for: "test_table")
         try await tile.writeGeoPackage(to: tempUrl, table: "test_table")
@@ -31,7 +31,7 @@ struct VectorTileGeoPackageTests {
             .appendingPathComponent("gpkg_\(UUID().uuidString).gpkg")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         let line = Feature(LineString([
             Coordinate3D(latitude: 10.0, longitude: 20.0),
@@ -53,7 +53,7 @@ struct VectorTileGeoPackageTests {
             .appendingPathComponent("gpkg_\(UUID().uuidString).gpkg")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         let line = Feature(LineString([
             Coordinate3D(latitude: 10.0, longitude: 20.0),
@@ -79,7 +79,7 @@ struct VectorTileGeoPackageTests {
             .appendingPathComponent("gpkg_\(UUID().uuidString).gpkg")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         let line = Feature(LineString([
             Coordinate3D(latitude: 10.0, longitude: 20.0),

--- a/Tests/MVTToolsTests/MLT/MLTRoundtripConvenienceTests.swift
+++ b/Tests/MVTToolsTests/MLT/MLTRoundtripConvenienceTests.swift
@@ -23,10 +23,10 @@ struct MLTRoundtripConvenienceTests {
             x: 0, y: 0, z: 0, projection: .epsg4326)
         else { return }
 
-        let tile = try #require(VectorTile(
+        let tile = try VectorTile(
             mltData: originalData,
             x: 0, y: 0, z: 0,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(tile.origin == .mlt)
         #expect(tile.layerNames.count == 2)
         #expect(tile.layerNames.contains("points"))
@@ -54,16 +54,16 @@ struct MLTRoundtripConvenienceTests {
             .appendingPathComponent("mlt_\(UUID().uuidString).mlt")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        let writeTile = try #require(VectorTile(
+        let writeTile = try VectorTile(
             mltData: data,
             x: 0, y: 0, z: 0,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(writeTile.writeMLT(to: tempUrl))
 
-        let readTile = try #require(VectorTile(
+        let readTile = try VectorTile(
             contentsOfMLT: tempUrl,
             x: 0, y: 0, z: 0,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(readTile.origin == .mlt)
         #expect(readTile.layerNames == ["test"])
     }
@@ -81,17 +81,17 @@ struct MLTRoundtripConvenienceTests {
             .appendingPathComponent("mlt_\(UUID().uuidString).mlt")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        let tile = try #require(VectorTile(
+        let tile = try VectorTile(
             mltData: data,
             x: 0, y: 0, z: 0,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(tile.writeMLT(to: tempUrl))
 
         let mapTile = MapTile(x: 0, y: 0, z: 0)
-        let readTile = try #require(VectorTile(
+        let readTile = try VectorTile(
             contentsOfMLT: tempUrl,
             tile: mapTile,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(readTile.origin == .mlt)
         #expect(readTile.layerNames == ["test"])
         #expect(readTile.x == 0)
@@ -105,10 +105,10 @@ struct MLTRoundtripConvenienceTests {
     func mvtToMltRoundtrip() throws {
         let mvtData = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
 
-        let mvtTile = try #require(VectorTile(
+        let mvtTile = try VectorTile(
             mvtData: mvtData,
             x: 8716, y: 8015, z: 14,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(mvtTile.origin == .mvt)
         #expect(mvtTile.layers.isEmpty == false)
 
@@ -118,18 +118,18 @@ struct MLTRoundtripConvenienceTests {
             projection: .epsg4326)
         else { return }
 
-        let mltTile = try #require(VectorTile(
+        let mltTile = try VectorTile(
             mltData: mltData,
             x: 8716, y: 8015, z: 14,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(mltTile.origin == .mlt)
         #expect(mltTile.layers.isEmpty == false)
 
         let mvt2Data = try #require(mltTile.mvtData())
-        let mvt2Tile = try #require(VectorTile(
+        let mvt2Tile = try VectorTile(
             mvtData: mvt2Data,
             x: 8716, y: 8015, z: 14,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(mvt2Tile.origin == .mvt)
         #expect(mvt2Tile.layers.isEmpty == false)
     }
@@ -151,17 +151,17 @@ struct MLTRoundtripConvenienceTests {
             projection: .epsg4326)
         else { return }
 
-        let mltTile = try #require(VectorTile(
+        let mltTile = try VectorTile(
             mltData: mltData,
             x: 8716, y: 8015, z: 14,
-            projection: .epsg4326))
+            projection: .epsg4326)
 
         let mvtData = try #require(mltTile.mvtData())
 
-        let mvtTile = try #require(VectorTile(
+        let mvtTile = try VectorTile(
             mvtData: mvtData,
             x: 8716, y: 8015, z: 14,
-            projection: .epsg4326))
+            projection: .epsg4326)
         #expect(mvtTile.origin == .mvt)
         #expect(mvtTile.layers.keys == mltTile.layers.keys)
 

--- a/Tests/MVTToolsTests/MVT/MVTEncoderTests.swift
+++ b/Tests/MVTToolsTests/MVT/MVTEncoderTests.swift
@@ -211,7 +211,7 @@ struct MVTEncoderTests {
     /// decode back, and verify the coordinate and feature ID match within precision limits.
     @Test
     func encodeDecode() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326))
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 25.0, longitude: 25.0)), id: .int(600))
         tile.addGeoJson(geoJson: point, layerName: "test")
 
@@ -221,7 +221,7 @@ struct MVTEncoderTests {
         #expect(features[0].id == .int(600))
 
         let tileData = try #require(tile.mvtData())
-        let decodedTile = try #require(VectorTile(mvtData: tileData, x: 0, y: 0, z: 0))
+        let decodedTile = try VectorTile(mvtData: tileData, x: 0, y: 0, z: 0)
 
         let decodedTileFeatures = decodedTile.features(for: "test")
         #expect(decodedTileFeatures.count == 1)
@@ -237,7 +237,7 @@ struct MVTEncoderTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
         let compressed = try #require(tile.mvtData(options: .init(compression: .default)))
 
         #expect(compressed.isGzipped)
@@ -251,10 +251,10 @@ struct MVTEncoderTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, layerAllowlist: ["building_label"]))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, layerAllowlist: ["building_label"])
 
         let bufferedTileData = try #require(tile.mvtData(options: .init(bufferSize: .extent(0))))
-        let bufferedTile = try #require(VectorTile(mvtData: bufferedTileData, x: 8716, y: 8015, z: 14))
+        let bufferedTile = try VectorTile(mvtData: bufferedTileData, x: 8716, y: 8015, z: 14)
 
         let features: [Point] = bufferedTile.features(for: "building_label").compactMap({ $0.geometry as? Point })
         let bounds = MapTile(x: 8716, y: 8015, z: 14).boundingBox(projection: .epsg4326)
@@ -270,17 +270,17 @@ struct MVTEncoderTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, layerAllowlist: ["road"]))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, layerAllowlist: ["road"])
 
         let simplifiedTileData = try #require(tile.mvtData(options: .init(bufferSize: .extent(4096), simplifyFeatures: .extent(1024))))
-        let simplifiedTile = try #require(VectorTile(mvtData: simplifiedTileData, x: 8716, y: 8015, z: 14))
+        let simplifiedTile = try VectorTile(mvtData: simplifiedTileData, x: 8716, y: 8015, z: 14)
         #expect(tile.features(for: "road").count == simplifiedTile.features(for: "road").count)
     }
 
     /// Tests encoding a tile with no layers produces valid protobuf data.
     @Test
     func emptyLayersProducesValidData() throws {
-        let tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        let tile = try VectorTile(x: 0, y: 0, z: 0)
         let data = tile.mvtData()
         #expect(data != nil)
     }
@@ -288,12 +288,12 @@ struct MVTEncoderTests {
     /// Tests encoding with EPSG:3857 projection round-trips correctly.
     @Test
     func encodeDecodeWithEpsg3857() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0, projection: .epsg3857))
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg3857)
         let point = Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg3857)), id: .int(100))
         tile.appendFeatures([point], to: "test")
 
         let data = try #require(tile.mvtData())
-        let decoded = try #require(VectorTile(mvtData: data, x: 0, y: 0, z: 0, projection: .epsg3857))
+        let decoded = try VectorTile(mvtData: data, x: 0, y: 0, z: 0, projection: .epsg3857)
         let decodedFeatures = decoded.features(for: "test")
         #expect(decodedFeatures.count == 1)
     }
@@ -301,12 +301,12 @@ struct MVTEncoderTests {
     /// Tests encoding with .noSRID projection round-trips correctly.
     @Test
     func encodeDecodeWithNoSRID() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0, projection: .noSRID))
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .noSRID)
         let point = Feature(Point(Coordinate3D(x: 100.0, y: 200.0, projection: .noSRID)), id: .int(101))
         tile.appendFeatures([point], to: "test")
 
         let data = try #require(tile.mvtData())
-        let decoded = try #require(VectorTile(mvtData: data, x: 0, y: 0, z: 0, projection: .noSRID))
+        let decoded = try VectorTile(mvtData: data, x: 0, y: 0, z: 0, projection: .noSRID)
         let decodedFeatures = decoded.features(for: "test")
         #expect(decodedFeatures.count == 1)
         #expect(abs((decodedFeatures[0].geometry as! Point).coordinate.x - 100.0) < 1.0)
@@ -316,7 +316,7 @@ struct MVTEncoderTests {
     /// Tests encoding with EPSG:4978 projection produces valid data.
     @Test
     func encodeWithEpsg4978() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0, projection: .epsg4978))
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4978)
         let point = Feature(Point(Coordinate3D(x: 0.0, y: 0.0, projection: .epsg4978)), id: .int(102))
         tile.appendFeatures([point], to: "test")
 

--- a/Tests/MVTToolsTests/OverzoomTests.swift
+++ b/Tests/MVTToolsTests/OverzoomTests.swift
@@ -18,8 +18,8 @@ struct OverzoomTests {
         y: Int,
         z: Int,
         projection: Projection = .epsg4326
-    ) -> VectorTile {
-        var tile = VectorTile(x: x, y: y, z: z, projection: projection)!
+    ) throws -> VectorTile {
+        var tile = try VectorTile(x: x, y: y, z: z, projection: projection)
         let bbox = MapTile(x: x, y: y, z: z).boundingBox(projection: .epsg4326)
         let centerLon = (bbox.southWest.longitude + bbox.northEast.longitude) / 2.0
         let centerLat = (bbox.southWest.latitude + bbox.northEast.latitude) / 2.0
@@ -82,7 +82,7 @@ struct OverzoomTests {
 
     @Test
     func overzoomByOne() throws {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         // Overzoom to NW child: z=3, x=2, y=2
         let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
 
@@ -93,7 +93,7 @@ struct OverzoomTests {
 
         // Encode to MVT (which clips) and decode to check features
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 2, y: 2, z: 3))
+        let decoded = try VectorTile(mvtData: data, x: 2, y: 2, z: 3)
 
         let features = decoded.features(for: "test")
         // The NW point should be in this child, the SE point should be clipped
@@ -104,7 +104,7 @@ struct OverzoomTests {
 
     @Test
     func overzoomByTwo() throws {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         // Overzoom to a grandchild at z=4
         // Children of 2/1/1: z=3 → (2,2), (3,2), (2,3), (3,3)
         // Children of 3/2/2: z=4 → (4,4), (5,4), (4,5), (5,5)
@@ -115,7 +115,7 @@ struct OverzoomTests {
         #expect(result.y == 4)
 
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 4, y: 4, z: 4))
+        let decoded = try VectorTile(mvtData: data, x: 4, y: 4, z: 4)
 
         let features = decoded.features(for: "test")
         // The NW point might be in this grandchild, depending on exact position
@@ -125,8 +125,8 @@ struct OverzoomTests {
     }
 
     @Test
-    func overzoomNonAncestorReturnsNil() {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+    func overzoomNonAncestorReturnsNil() throws {
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         // z=3/x=0/y=0 is NOT a child of z=2/x=1/y=1
         let result = source.rezoom(toTargetX: 0, targetY: 0, targetZ: 3)
         #expect(result == nil)
@@ -137,7 +137,7 @@ struct OverzoomTests {
     @Test
     func underzoomByOne() throws {
         // Source at z=3/x=2/y=2 (a child of z=2/x=1/y=1)
-        let source = makeSourceTile(x: 2, y: 2, z: 3)
+        let source = try makeSourceTile(x: 2, y: 2, z: 3)
         let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
 
         #expect(result.z == 2)
@@ -146,7 +146,7 @@ struct OverzoomTests {
 
         // Encode and decode — all features from the child should be in the parent
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 1, y: 1, z: 2))
+        let decoded = try VectorTile(mvtData: data, x: 1, y: 1, z: 2)
 
         let features = decoded.features(for: "test")
         let names = Set(features.compactMap { $0.properties["name"] as? String })
@@ -159,21 +159,21 @@ struct OverzoomTests {
     func underzoomMultipleChildren() throws {
         // Create all 4 children of z=2/x=1/y=1 at z=3
         let children: [VectorTile] = [
-            makeSourceTile(x: 2, y: 2, z: 3),
-            makeSourceTile(x: 3, y: 2, z: 3),
-            makeSourceTile(x: 2, y: 3, z: 3),
-            makeSourceTile(x: 3, y: 3, z: 3),
+            try makeSourceTile(x: 2, y: 2, z: 3),
+            try makeSourceTile(x: 3, y: 2, z: 3),
+            try makeSourceTile(x: 2, y: 3, z: 3),
+            try makeSourceTile(x: 3, y: 3, z: 3),
         ]
 
         // Underzoom all 4 into their parent at z=2/x=1/y=1
-        let result = VectorTile.rezoom(children, toTargetX: 1, targetY: 1, targetZ: 2)
+        let result = try VectorTile.rezoom(children, toTargetX: 1, targetY: 1, targetZ: 2)
 
         #expect(result.z == 2)
         #expect(result.x == 1)
         #expect(result.y == 1)
 
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 1, y: 1, z: 2))
+        let decoded = try VectorTile(mvtData: data, x: 1, y: 1, z: 2)
 
         let features = decoded.features(for: "test")
         // Each child contributed 2 features → 8 total
@@ -181,8 +181,8 @@ struct OverzoomTests {
     }
 
     @Test
-    func underzoomNonAncestorReturnsNil() {
-        let source = makeSourceTile(x: 0, y: 0, z: 3)
+    func underzoomNonAncestorReturnsNil() throws {
+        let source = try makeSourceTile(x: 0, y: 0, z: 3)
         // z=2/x=1/y=1 is NOT the parent of z=3/x=0/y=0
         let result = source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2)
         #expect(result == nil)
@@ -192,7 +192,7 @@ struct OverzoomTests {
 
     @Test
     func rezoomSameZoom() throws {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
 
         #expect(result.z == 2)
@@ -204,8 +204,8 @@ struct OverzoomTests {
     }
 
     @Test
-    func rezoomSameZoomDifferentTileReturnsNil() {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+    func rezoomSameZoomDifferentTileReturnsNil() throws {
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         let result = source.rezoom(toTargetX: 2, targetY: 2, targetZ: 2)
         #expect(result == nil)
     }
@@ -215,8 +215,9 @@ struct OverzoomTests {
     @Test
     func overzoomAllProjections() throws {
         for projection in [Projection.epsg4326, .epsg3857, .epsg4978, .noSRID] {
-            let source = makeSourceTile(x: 1, y: 1, z: 2, projection: projection)
+            let source = try makeSourceTile(x: 1, y: 1, z: 2, projection: projection)
             let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
+
 
             #expect(result.projection == projection)
             #expect(result.z == 3)
@@ -232,8 +233,9 @@ struct OverzoomTests {
     @Test
     func underzoomAllProjections() throws {
         for projection in [Projection.epsg4326, .epsg3857, .epsg4978, .noSRID] {
-            let source = makeSourceTile(x: 2, y: 2, z: 3, projection: projection)
+            let source = try makeSourceTile(x: 2, y: 2, z: 3, projection: projection)
             let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
+
 
             #expect(result.projection == projection)
             #expect(result.z == 2)
@@ -249,13 +251,13 @@ struct OverzoomTests {
     func overzoomMvtRoundTrip() throws {
         // Use the real test data tile
         let mvtData = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let source = try #require(VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14))
+        let source = try VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14)
 
         // Overzoom to z=15, NW child (x=17432, y=16030)
         let result = try #require(source.rezoom(toTargetX: 17432, targetY: 16030, targetZ: 15))
 
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 17432, y: 16030, z: 15))
+        let decoded = try VectorTile(mvtData: data, x: 17432, y: 16030, z: 15)
 
         // Should have some layers with features (the NW quadrant of the original tile)
         #expect(decoded.layerNames.isNotEmpty)
@@ -266,13 +268,13 @@ struct OverzoomTests {
     @Test
     func underzoomMvtRoundTrip() throws {
         let mvtData = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let source = try #require(VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14))
+        let source = try VectorTile(mvtData: mvtData, x: 8716, y: 8015, z: 14)
 
         // Underzoom to z=13, parent (x=4358, y=4007)
         let result = try #require(source.rezoom(toTargetX: 4358, targetY: 4007, targetZ: 13))
 
         let data = try #require(result.mvtData(options: .init(bufferSize: .extent(512))))
-        let decoded = try #require(VectorTile(mvtData: data, x: 4358, y: 4007, z: 13))
+        let decoded = try VectorTile(mvtData: data, x: 4358, y: 4007, z: 13)
 
         // All features should be retained (the source is within the parent)
         #expect(decoded.layerNames.isNotEmpty)
@@ -284,7 +286,7 @@ struct OverzoomTests {
 
     @Test
     func overzoomGeoJsonRoundTrip() throws {
-        let source = makeSourceTile(x: 1, y: 1, z: 2)
+        let source = try makeSourceTile(x: 1, y: 1, z: 2)
         let result = try #require(source.rezoom(toTargetX: 2, targetY: 2, targetZ: 3))
 
         let data = try #require(result.toGeoJson(options: .init(bufferSize: .extent(0))))
@@ -296,7 +298,7 @@ struct OverzoomTests {
 
     @Test
     func underzoomGeoJsonRoundTrip() throws {
-        let source = makeSourceTile(x: 2, y: 2, z: 3)
+        let source = try makeSourceTile(x: 2, y: 2, z: 3)
         let result = try #require(source.rezoom(toTargetX: 1, targetY: 1, targetZ: 2))
 
         let data = try #require(result.toGeoJson(options: .init(bufferSize: .extent(0))))
@@ -311,13 +313,13 @@ struct OverzoomTests {
     @Test
     func rezoomMixedSources() throws {
         // Source at z=2 (ancestor of target z=3)
-        let sourceA = makeSourceTile(x: 1, y: 1, z: 2)
+        let sourceA = try makeSourceTile(x: 1, y: 1, z: 2)
         // Source at z=3 (same zoom as target, same tile → identity)
-        let sourceB = makeSourceTile(x: 2, y: 2, z: 3)
+        let sourceB = try makeSourceTile(x: 2, y: 2, z: 3)
         // Source at z=4 (descendant of target z=3)
-        let sourceC = makeSourceTile(x: 4, y: 4, z: 4)
+        let sourceC = try makeSourceTile(x: 4, y: 4, z: 4)
 
-        let result = VectorTile.rezoom(
+        let result = try VectorTile.rezoom(
             [sourceA, sourceB, sourceC],
             toTargetX: 2,
             targetY: 2,
@@ -335,10 +337,10 @@ struct OverzoomTests {
 
     @Test
     func rezoomSkipsInvalidSources() throws {
-        let validSource = makeSourceTile(x: 1, y: 1, z: 2)
-        let invalidSource = makeSourceTile(x: 0, y: 0, z: 2) // not an ancestor of 3/2/2
+        let validSource = try makeSourceTile(x: 1, y: 1, z: 2)
+        let invalidSource = try makeSourceTile(x: 0, y: 0, z: 2) // not an ancestor of 3/2/2
 
-        let result = VectorTile.rezoom(
+        let result = try VectorTile.rezoom(
             [validSource, invalidSource],
             toTargetX: 2,
             targetY: 2,

--- a/Tests/MVTToolsTests/QueryTests.swift
+++ b/Tests/MVTToolsTests/QueryTests.swift
@@ -24,7 +24,7 @@ struct QueryTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
         #expect(tile.isIndexed == false)
 
         let result = tile.query(at: Coordinate3D(latitude: 3.870163, longitude: 11.518585), tolerance: 100.0)
@@ -38,7 +38,7 @@ struct QueryTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, indexed: .hilbert))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14, indexed: .hilbert)
         #expect(tile.isIndexed)
 
         let resultWithIndex = tile.query(at: Coordinate3D(latitude: 3.870163, longitude: 11.518585), tolerance: 100.0)
@@ -49,7 +49,7 @@ struct QueryTests {
     @Test
     func textSearch() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let results = tile.query(term: "lake")
         // Results may be empty if no feature properties contain "lake",
@@ -64,7 +64,7 @@ struct QueryTests {
     @Test
     func textSearchNoMatch() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let results = tile.query(term: "zzzxxxyyy_nonexistent")
         #expect(results.isEmpty)
@@ -74,7 +74,7 @@ struct QueryTests {
     @Test
     func queryInSpecificLayer() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let results = tile.query(at: Coordinate3D(latitude: 3.870163, longitude: 11.518585), tolerance: 100.0, layerName: "road")
         #expect(results.isNotEmpty)
@@ -85,7 +85,7 @@ struct QueryTests {
     @Test
     func queryMany() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let coordinates = [
             Coordinate3D(latitude: 3.870163, longitude: 11.518585),
@@ -100,7 +100,7 @@ struct QueryTests {
     @Test
     func queryWithFeatureFilter() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
         let allResults = tile.query(at: Coordinate3D(latitude: 3.870163, longitude: 11.518585), tolerance: 100.0)
         let filteredResults = tile.query(
@@ -115,7 +115,7 @@ struct QueryTests {
     /// Tests that createIndex with a Hilbert sort option produces an indexed tile.
     @Test
     func createIndex() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.appendFeatures([feature], to: "test")
 

--- a/Tests/MVTToolsTests/Shapefile/ShapefileCoderTests.swift
+++ b/Tests/MVTToolsTests/Shapefile/ShapefileCoderTests.swift
@@ -23,8 +23,8 @@ struct VectorTileShapefileTests {
         let fc = FeatureCollection(points)
         try ShapefileCoder.write(fc, to: shapefileUrl)
 
-        let tile = try #require(VectorTile(
-            shapefile: shapefileUrl.appendingPathExtension("shp")))
+        let tile = try VectorTile(
+            shapefile: shapefileUrl.appendingPathExtension("shp"))
         #expect(tile.origin == .shapefile)
         #expect(tile.layerNames == ["test_points"])
         #expect(tile.features(for: "test_points").count == 2)
@@ -37,7 +37,7 @@ struct VectorTileShapefileTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         tile.setFeatures([point], for: "test_layer")
 
@@ -46,7 +46,7 @@ struct VectorTileShapefileTests {
         #expect(FileManager.default.fileExists(atPath: outputUrl.appendingPathExtension("shp").path))
         #expect(FileManager.default.fileExists(atPath: outputUrl.appendingPathExtension("dbf").path))
 
-        let readTile = try #require(VectorTile(shapefile: outputUrl.appendingPathExtension("shp")))
+        let readTile = try VectorTile(shapefile: outputUrl.appendingPathExtension("shp"))
         #expect(readTile.origin == .shapefile)
         #expect(readTile.layers.values.reduce(0) { $0 + $1.features.count } == 1)
     }
@@ -58,7 +58,7 @@ struct VectorTileShapefileTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         let line = Feature(LineString([
             Coordinate3D(latitude: 10.0, longitude: 20.0),
@@ -75,7 +75,7 @@ struct VectorTileShapefileTests {
 
     @Test
     func shapefileMixedGeometryError() throws {
-        var tile = VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)!
+        var tile = try VectorTile(x: 0, y: 0, z: 0, projection: .epsg4326)
         let point = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 20.0)), id: .int(1))
         let line = Feature(LineString([
             Coordinate3D(latitude: 10.0, longitude: 20.0),

--- a/Tests/MVTToolsTests/TileDataContentConsistencyTests.swift
+++ b/Tests/MVTToolsTests/TileDataContentConsistencyTests.swift
@@ -146,8 +146,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let mltData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.mlt")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let mltTile = try #require(VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let mltTile = try VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14)
 
         #expect(mvtTile.layerNames.sorted() == mltTile.layerNames.sorted())
 
@@ -164,8 +164,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let mltData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.mlt")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let mltTile = try #require(VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let mltTile = try VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14)
 
         let mvtTotal = mvtTile.layers.values.reduce(0) { $0 + $1.features.count }
         let mltTotal = mltTile.layers.values.reduce(0) { $0 + $1.features.count }
@@ -179,8 +179,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let geoJsonData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.geojson")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let geoJsonTile = try #require(VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer"))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let geoJsonTile = try VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer")
 
         let mvtRaw = mvtTile.layers.values.reduce(0) { $0 + $1.features.count }
         let mvtFlat = mvtTile.layerNames.reduce(0) { $0 + flattenedFeatures(mvtTile.features(for: $1)).count }
@@ -198,8 +198,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let mltData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.mlt")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let mltTile = try #require(VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let mltTile = try VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14)
 
         for layerName in mvtTile.layerNames {
             let mvtFeatures = mvtTile.features(for: layerName)
@@ -222,8 +222,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let mltData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.mlt")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let mltTile = try #require(VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let mltTile = try VectorTile(mltData: mltData, x: 8657, y: 5725, z: 14)
 
         for layerName in mvtTile.layerNames {
             let mvtFeatures = mvtTile.features(for: layerName)
@@ -254,8 +254,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let geoJsonData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.geojson")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let geoJsonTile = try #require(VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer"))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let geoJsonTile = try VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer")
 
         for layerName in mvtTile.layerNames {
             let mvtFeatures = flattenedFeatures(mvtTile.features(for: layerName))
@@ -277,8 +277,8 @@ struct TileDataContentConsistencyTests {
         let mvtData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.pbf")
         let geoJsonData = try TestData.dataFromFile(name: "immenstadt_14_8657_5725.geojson")
 
-        let mvtTile = try #require(VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14))
-        let geoJsonTile = try #require(VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer"))
+        let mvtTile = try VectorTile(mvtData: mvtData, x: 8657, y: 5725, z: 14)
+        let geoJsonTile = try VectorTile(geoJsonData: geoJsonData, layerProperty: "vt_layer")
 
         for layerName in mvtTile.layerNames {
             let mvtFeatures = flattenedFeatures(mvtTile.features(for: layerName))

--- a/Tests/MVTToolsTests/VectorTileTests.swift
+++ b/Tests/MVTToolsTests/VectorTileTests.swift
@@ -18,10 +18,10 @@ struct VectorTileTests {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
         #expect(mvt.isEmpty == false)
 
-        let layerNames = VectorTile.layerNames(from: mvt)?.sorted()
+        let layerNames = try VectorTile.layerNames(from: mvt)?.sorted()
         #expect(layerNames == tileLayerNames)
 
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
         #expect(tile.layerNames.sorted() == tileLayerNames)
 
         let _ = try #require(tile.toGeoJson(prettyPrinted: true))
@@ -35,7 +35,7 @@ struct VectorTileTests {
     /// encoding to MVT data, and verifying it produces valid output.
     @Test
     func writeMvt() throws {
-        var tile = try #require(VectorTile(x: 8716, y: 8015, z: 14))
+        var tile = try VectorTile(x: 8716, y: 8015, z: 14)
 
         var feature = Feature(Point(Coordinate3D(latitude: 3.870163, longitude: 11.518585)))
         feature.properties = [
@@ -68,9 +68,9 @@ struct VectorTileTests {
     /// from both source tiles appear in the result.
     @Test
     func merge() throws {
-        var tile1 = try #require(VectorTile(x: 0, y: 0, z: 0))
-        var tile2 = try #require(VectorTile(x: 0, y: 0, z: 0))
-        var tile3 = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile1 = try VectorTile(x: 0, y: 0, z: 0)
+        var tile2 = try VectorTile(x: 0, y: 0, z: 0)
+        var tile3 = try VectorTile(x: 0, y: 0, z: 0)
 
         #expect(tile1.features(for: "test1").count == 0)
         #expect(tile1.features(for: "test2").count == 0)
@@ -101,12 +101,12 @@ struct VectorTileTests {
         let feature = try #require(Feature(jsonData: TestData.dataFromFile(name: "bigint_id.geojson")))
         #expect(feature.id == .uint(18_446_744_073_638_380_036))
 
-        var tile = try #require(VectorTile(x: 10, y: 25, z: 6))
+        var tile = try VectorTile(x: 10, y: 25, z: 6)
         tile.setFeatures([feature], for: "test")
         let tileData = try #require(tile.mvtData())
         #expect(tileData.isEmpty == false)
 
-        let tile2 = try #require(VectorTile(mvtData: tileData, x: 10, y: 25, z: 6))
+        let tile2 = try VectorTile(mvtData: tileData, x: 10, y: 25, z: 6)
         let feature2: Feature = try #require(tile2.features(for: "test").first)
 
         #expect(feature.id == feature2.id)
@@ -116,9 +116,9 @@ struct VectorTileTests {
     @Test
     func extractLayers() throws {
         let mvt = try TestData.dataFromFile(name: "14_8716_8015.vector.mvt")
-        let tile = try #require(VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14))
+        let tile = try VectorTile(mvtData: mvt, x: 8716, y: 8015, z: 14)
 
-        let extracted = try #require(tile.extract(layerNames: ["road", "building"]))
+        let extracted = try tile.extract(layerNames: ["road", "building"])
         #expect(extracted.layerNames.count == 2)
         #expect(extracted.hasLayer("road"))
         #expect(extracted.hasLayer("building"))
@@ -128,7 +128,7 @@ struct VectorTileTests {
     /// Tests that `clear()` removes all layers and features from a tile.
     @Test
     func clearRemovesAllContent() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.appendFeatures([feature], to: "test")
 
@@ -143,7 +143,7 @@ struct VectorTileTests {
     /// Tests that `isEmpty` returns true for a newly created empty tile.
     @Test
     func isEmptyForNewTile() throws {
-        let tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        let tile = try VectorTile(x: 0, y: 0, z: 0)
         #expect(tile.isEmpty)
         #expect(tile.layersWithContent.isEmpty)
     }
@@ -151,7 +151,7 @@ struct VectorTileTests {
     /// Tests that `hasLayer(_:)` correctly identifies present and absent layers.
     @Test
     func hasLayer() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         #expect(tile.hasLayer("test") == false)
 
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
@@ -162,7 +162,7 @@ struct VectorTileTests {
     /// Tests that `removeLayer(_:)` removes the layer and returns its features.
     @Test
     func removeLayer() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.appendFeatures([feature], to: "test")
 
@@ -175,7 +175,7 @@ struct VectorTileTests {
     /// Tests that `removeFeatures(fromLayer:where:)` removes only matching features.
     @Test
     func removeFeaturesWhere() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature1 = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         let feature2 = Feature(Point(Coordinate3D(latitude: 20.0, longitude: 20.0)))
 
@@ -189,25 +189,35 @@ struct VectorTileTests {
         #expect(tile.features(for: "test").first?.geometry.allCoordinates.first?.latitude == 20.0)
     }
 
-    /// Tests that invalid tile coordinates (negative x/y/z) return nil.
+    /// Tests that invalid tile coordinates (negative x/y/z) throw.
     @Test
     func invalidCoordinatesReturnNil() {
-        #expect(VectorTile(x: -1, y: 0, z: 0) == nil)
-        #expect(VectorTile(x: 0, y: -1, z: 0) == nil)
-        #expect(VectorTile(x: 0, y: 0, z: -1) == nil)
+        #expect(throws: VectorTileError.invalidCoordinate(x: -1, y: 0, z: 0)) {
+            try VectorTile(x: -1, y: 0, z: 0)
+        }
+        #expect(throws: VectorTileError.invalidCoordinate(x: 0, y: -1, z: 0)) {
+            try VectorTile(x: 0, y: -1, z: 0)
+        }
+        #expect(throws: VectorTileError.invalidCoordinate(x: 0, y: 0, z: -1)) {
+            try VectorTile(x: 0, y: 0, z: -1)
+        }
     }
 
-    /// Tests that tile coordinates exceeding the maximum at a given zoom level return nil.
+    /// Tests that tile coordinates exceeding the maximum at a given zoom level throw.
     @Test
     func outOfBoundsCoordinatesReturnNil() {
-        #expect(VectorTile(x: 4, y: 2, z: 2) == nil)
-        #expect(VectorTile(x: 2, y: 4, z: 2) == nil)
+        #expect(throws: VectorTileError.coordinateOutOfBounds(x: 4, y: 2, z: 2, maxBound: 4)) {
+            try VectorTile(x: 4, y: 2, z: 2)
+        }
+        #expect(throws: VectorTileError.coordinateOutOfBounds(x: 2, y: 4, z: 2, maxBound: 4)) {
+            try VectorTile(x: 2, y: 4, z: 2)
+        }
     }
 
     /// Tests that `layersWithContent` only includes layers that have features.
     @Test
     func layersWithContent() throws {
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
 
         #expect(tile.layersWithContent.isEmpty)
@@ -226,14 +236,14 @@ struct VectorTileTests {
             .appendingPathComponent("test_write_to_file_\(UUID().uuidString).mvt")
         defer { try? FileManager.default.removeItem(at: tempUrl) }
 
-        var tile = try #require(VectorTile(x: 0, y: 0, z: 0))
+        var tile = try VectorTile(x: 0, y: 0, z: 0)
         let feature = Feature(Point(Coordinate3D(latitude: 10.0, longitude: 10.0)))
         tile.appendFeatures([feature], to: "test")
 
         let success = tile.writeMVT(to: tempUrl)
         #expect(success)
 
-        let readTile = try #require(VectorTile(contentsOfMVT: tempUrl, x: 0, y: 0, z: 0))
+        let readTile = try VectorTile(contentsOfMVT: tempUrl, x: 0, y: 0, z: 0)
         #expect(readTile.features(for: "test").count == 1)
     }
 
@@ -246,9 +256,8 @@ struct VectorTileTests {
 
     /// Tests that `layerNames(from:)` returns an empty array for empty protobuf data.
     @Test
-    func layerNamesFromEmptyData() {
-        let names = VectorTile.layerNames(from: Data())
-        #expect(names != nil)
+    func layerNamesFromEmptyData() throws {
+        let names = try VectorTile.layerNames(from: Data())
         #expect(names?.isEmpty == true)
     }
 
@@ -257,7 +266,7 @@ struct VectorTileTests {
     @Test
     func initWithMapTile() throws {
         let mapTile = MapTile(x: 100, y: 200, z: 8)
-        let tile = try #require(VectorTile(tile: mapTile, projection: .epsg3857))
+        let tile = try VectorTile(tile: mapTile, projection: .epsg3857)
 
         #expect(tile.x == 100)
         #expect(tile.y == 200)


### PR DESCRIPTION
## Summary

Converts all failable `init?` convenience initializers on `VectorTile` to throwing `init throws`, surfacing typed errors instead of silently returning `nil`.

## Changes

- **New `VectorTileError` enum** — public error type with `LocalizedError` conformance for human-readable messages:
  - `.invalidCoordinate(x:y:z:)`
  - `.coordinateOutOfBounds(x:y:z:maxBound:)`
  - `.fileReadFailed(url:reason:)`
  - `.parseFailed(format:reason:)`
- **17 failable inits → throwing** across `VectorTile.swift`, `VectorTile+MVT.swift`, `VectorTile+MLT.swift`, `VectorTile+GeoJSON.swift`, `VectorTile+GPX.swift`, `VectorTile+FIT.swift`, `VectorTile+Shapefile.swift`
- **MLT decoding errors** are no longer swallowed by `try?` — they propagate through `VectorTileError.parseFailed`
- **File I/O errors** now propagate as `VectorTileError.fileReadFailed` instead of being caught and returning `nil`
- **`TileFormat.loadTile()`** now returns non-optional `VectorTile` (errors propagate naturally)
- **CLI commands** receive typed, human-readable errors instead of generic fallback messages

## ⚠️ Breaking Change

All callers of `VectorTile(...)` convenience initializers must now use `try` instead of optional binding (`if let` / `guard let`). The return type is now `VectorTile` (non-optional).

## Test Results

All 250 tests pass.